### PR TITLE
chore: tweaks based on feedback to factory contracts

### DIFF
--- a/packages/contracts/contracts/GrantRoundFactory.sol
+++ b/packages/contracts/contracts/GrantRoundFactory.sol
@@ -30,7 +30,7 @@ contract GrantRoundFactory is Ownable {
   event GrantRoundContractUpdated(address grantRoundAddress);
 
   /// @notice Emitted when a new GrantRound is created
-  event GrantRoundCreated(address grantRoundAddress);
+  event GrantRoundCreated(address indexed grantRoundAddress);
 
 
   // --- Core methods ---

--- a/packages/contracts/contracts/GrantRoundFactory.sol
+++ b/packages/contracts/contracts/GrantRoundFactory.sol
@@ -30,7 +30,7 @@ contract GrantRoundFactory is Ownable {
   event GrantRoundContractUpdated(address grantRoundAddress);
 
   /// @notice Emitted when a new GrantRound is created
-  event GrantRoundCreated(address indexed grantRoundAddress);
+  event GrantRoundCreated(address indexed grantRoundAddress, address indexed ownedBy);
 
 
   // --- Core methods ---
@@ -55,6 +55,7 @@ contract GrantRoundFactory is Ownable {
    * @param _roundStartTime Unix timestamp of the start of the round
    * @param _roundEndTime Unix timestamp of the end of the round
    * @param _token Address of the ERC20 token for accepting matching pool contributions
+    * @param _ownedBy Program which created the contract
    * @param _metaPtr URL pointing to the grant round metadata
    * @param _roundOperators Addresses to be granted ROUND_OPERATOR_ROLE
    */
@@ -64,13 +65,14 @@ contract GrantRoundFactory is Ownable {
     uint256 _roundStartTime,
     uint256 _roundEndTime,
     IERC20 _token,
+    address _ownedBy,
     MetaPtr calldata _metaPtr,
     address[] calldata _roundOperators
   ) external returns (address) {
 
-    address clone = Clones.clone(grantRoundContract);
+    address _clone = Clones.clone(grantRoundContract);
 
-    GrantRoundImplementation(clone).initialize(
+    GrantRoundImplementation(_clone).initialize(
       _votingContract,
       _grantApplicationsStartTime,
       _roundStartTime,
@@ -80,9 +82,9 @@ contract GrantRoundFactory is Ownable {
       _roundOperators
     );
 
-    emit GrantRoundCreated(clone);
+    emit GrantRoundCreated(_clone, _ownedBy);
 
-    return clone;
+    return _clone;
   }
 
 }

--- a/packages/contracts/contracts/program/ProgramFactory.sol
+++ b/packages/contracts/contracts/program/ProgramFactory.sol
@@ -17,7 +17,7 @@ contract ProgramFactory is Ownable {
   event ProgramContractUpdated(address programContractAddress);
 
   /// @notice Emitted when a new Program is created
-  event ProgramCreated(address programContractAddress);
+  event ProgramCreated(address indexed programContractAddress);
 
 
   /**

--- a/packages/contracts/docs/CHAINS.md
+++ b/packages/contracts/docs/CHAINS.md
@@ -6,7 +6,7 @@ This document lists all the addresses of the contracts that have been deployed o
 
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0x191DE462AFfcD7c45db63A80756d6eEdD1a66709 |
+| goerli  | 0x2f97819a05051cC0983988B9E49331E679741309 |
 
 
 ## GrantRoundImplementation
@@ -28,7 +28,7 @@ This document lists all the addresses of the contracts that have been deployed o
 This is not the exahustive list but instead just shows example of a round deployed on network
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0xd8a6336a33a35a66de3c393663aad012e8a1d4cc |
+| goerli  | 0x9e1acfba605339823baeb5edad2eebaf6e1f8363 |
 
 
 
@@ -36,7 +36,7 @@ This is not the exahustive list but instead just shows example of a round deploy
 
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0x0EbD2E2130b73107d0C45fF2E16c93E7e2e10e3a |
+| goerli  | 0x1542143A64DcFa25Ddeb3CAf79F538B4a04F3FDd |
 
 
 ## ProgramImplementation
@@ -44,3 +44,11 @@ This is not the exahustive list but instead just shows example of a round deploy
 | Network | Address                                    |
 |---------|--------------------------------------------|
 | goerli  | 0x54457339Ca7Cc674f035ed2456d68631672733b7 |
+
+
+## Program
+
+This is not the exahustive list but instead just shows example of a program deployed on network
+| Network | Address                                    |
+|---------|--------------------------------------------|
+| goerli  | 0x544f3223b69db0a149a257f38f8f1a8b55fddbf7 |

--- a/packages/contracts/scripts/config/program.config.ts
+++ b/packages/contracts/scripts/config/program.config.ts
@@ -9,6 +9,6 @@ type DeployParams = Record<string, ProgramParams>;
 export const programParams: DeployParams = {
   goerli: {
     programImplementationContract: '0x54457339Ca7Cc674f035ed2456d68631672733b7',
-    programFactoryContract: '0x0EbD2E2130b73107d0C45fF2E16c93E7e2e10e3a'
+    programFactoryContract: '0x1542143A64DcFa25Ddeb3CAf79F538B4a04F3FDd'
   },
 };

--- a/packages/contracts/scripts/config/round.config.ts
+++ b/packages/contracts/scripts/config/round.config.ts
@@ -10,7 +10,7 @@ type DeployParams = Record<string, RoundParams>;
 export const roundParams: DeployParams = {
   goerli: {
     grantRoundImplementationContract: '0xc2B040cdd5fba17779ca2d81c4214d590Db885A9',
-    grantRoundFactoryContract: '0x191DE462AFfcD7c45db63A80756d6eEdD1a66709',
+    grantRoundFactoryContract: '0x2f97819a05051cC0983988B9E49331E679741309',
     bulkVoteContract: '0xc76Ea06e2BC6476178e40E2B40bf5C6Bf3c40EF6'
   },
 };

--- a/packages/contracts/scripts/round/createGrantRound.ts
+++ b/packages/contracts/scripts/round/createGrantRound.ts
@@ -48,6 +48,7 @@ export async function main() {
       startTime, // _roundStartTime
       endTime, // _roundEndTime
       '0x7f329D36FeA6b3AD10E6e36f2728e7e6788a938D', // _token
+      '0x43b1969ffb76ed334878cee591ffb2c5b5607088', // _ownedBy
       { protocol: 1, pointer: "QmXVTmCGPnkYhCCiT7zyaK3HezVwijue4o7RH6BEY9Rmzu" }, // _metaPtr
       ['0x5cdb35fADB8262A3f88863254c870c2e6A848CcA', '0xB8cEF765721A6da910f14Be93e7684e9a3714123'] // _roundOperators
   );


### PR DESCRIPTION
##### Description

- ensure event is indexable on creation
- add prefix `_` to internal variable
- when round is created, expect deployer to pass program address (solely used for firing an event) 
 

##### Testing

programFactoryContract : 0x1542143A64DcFa25Ddeb3CAf79F538B4a04F3FDd
programImplementationContract:  0x54457339Ca7Cc674f035ed2456d68631672733b7
Program created:  0xbd4b0db965d02308fd7b7f31eb25ec010cdbee3c5aa72f82a9e88f8176f6b6f0


grantRoundFactoryContract :  0x2f97819a05051cC0983988B9E49331E679741309
grantRoundImplementationContract: 0xc2B040cdd5fba17779ca2d81c4214d590Db885A9
GrantRound created:  0x0cdabe49c870238732bf35ee86686ca8c471bee95e1bcf287d6ea2a1f26f6d67
