### PR TITLE
chore: migrate from Clones -> ClonesUpgradeable

### DIFF
--- a/packages/contracts/contracts/dummy/upgradeCheck/dummyProgramFactory.sol
+++ b/packages/contracts/contracts/dummy/upgradeCheck/dummyProgramFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/proxy/Clones.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../../utils/MetaPtr.sol";
 
@@ -35,7 +35,7 @@ contract DummyProgramFactory is OwnableUpgradeable {
     string calldata _message
   ) external returns (address) {
 
-    address clone = Clones.clone(programContract);
+    address clone = ClonesUpgradeable.clone(programContract);
 
     DummyProgramImplementation(clone).initialize(
       _metaPtr,

--- a/packages/contracts/contracts/program/ProgramFactory.sol
+++ b/packages/contracts/contracts/program/ProgramFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/proxy/Clones.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/ClonesUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "../utils/MetaPtr.sol";
 
@@ -49,7 +49,7 @@ contract ProgramFactory is OwnableUpgradeable {
     address[] calldata _programOperators
   ) external returns (address) {
 
-    address clone = Clones.clone(programContract);
+    address clone = ClonesUpgradeable.clone(programContract);
 
     ProgramImplementation(clone).initialize(
       _metaPtr,

--- a/packages/contracts/docs/CHAINS.md
+++ b/packages/contracts/docs/CHAINS.md
@@ -36,14 +36,14 @@ This is not the exahustive list but instead just shows example of a round deploy
 
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0x1542143A64DcFa25Ddeb3CAf79F538B4a04F3FDd |
+| goerli  | 0xCB08d3a6cAe32443873537D502b22270C77e27e1 |
 
 
 ## ProgramImplementation
 
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0x54457339Ca7Cc674f035ed2456d68631672733b7 |
+| goerli  | 0x7492612F252eAb2c93E9FfDd4Bea47c2C70f3479 |
 
 
 ## Program
@@ -51,4 +51,4 @@ This is not the exahustive list but instead just shows example of a round deploy
 This is not the exahustive list but instead just shows example of a program deployed on network
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0x544f3223b69db0a149a257f38f8f1a8b55fddbf7 |
+| goerli  | 0x1564f459600505734cffe7a075691db96e517ae7 |

--- a/packages/contracts/scripts/config/program.config.ts
+++ b/packages/contracts/scripts/config/program.config.ts
@@ -8,7 +8,7 @@ type DeployParams = Record<string, ProgramParams>;
 
 export const programParams: DeployParams = {
   goerli: {
-    programImplementationContract: '0x54457339Ca7Cc674f035ed2456d68631672733b7',
-    programFactoryContract: '0x1542143A64DcFa25Ddeb3CAf79F538B4a04F3FDd'
+    programImplementationContract: '0x7492612F252eAb2c93E9FfDd4Bea47c2C70f3479',
+    programFactoryContract: '0xCB08d3a6cAe32443873537D502b22270C77e27e1'
   },
 };


### PR DESCRIPTION
##### Description

Based on feedback from @ gravityblast
Using ClonesUpgradeable to keep the library consistent
Documentation has been updated with new deployed contracts


##### Testing

Tested on goerli 