### PR TITLE
bug: ensure admin_role of grant round is set right

### DIFF
--- a/packages/contracts/contracts/GrantRoundFactory.sol
+++ b/packages/contracts/contracts/GrantRoundFactory.sol
@@ -79,6 +79,7 @@ contract GrantRoundFactory is Ownable {
       _roundEndTime,
       _token,
       _metaPtr,
+      msg.sender,
       _roundOperators
     );
 

--- a/packages/contracts/contracts/GrantRoundImplementation.sol
+++ b/packages/contracts/contracts/GrantRoundImplementation.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 
-import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -17,7 +17,7 @@ import "./utils/MetaPtr.sol";
  * a group of ROUND_OPERATOR via the GrantRoundFactory
  *
  */
-contract GrantRoundImplementation is AccessControl, Initializable {
+contract GrantRoundImplementation is AccessControlEnumerable, Initializable {
 
   // --- Libraries ---
   using Address for address;
@@ -69,6 +69,7 @@ contract GrantRoundImplementation is AccessControl, Initializable {
    * @param _roundEndTime Unix timestamp of the end of the round
    * @param _token Address of the ERC20 token for accepting matching pool contributions
    * @param _metaPtr URL pointing to the grant round metadata
+   * @param _adminRole Address to be granted DEFAULT_ADMIN_ROLE
    * @param _roundOperators Addresses to be granted ROUND_OPERATOR_ROLE
    */
   function initialize(
@@ -78,6 +79,7 @@ contract GrantRoundImplementation is AccessControl, Initializable {
     uint256 _roundEndTime,
     IERC20 _token,
     MetaPtr memory _metaPtr,
+    address _adminRole,
     address[] memory _roundOperators
   ) public initializer {
 
@@ -94,7 +96,7 @@ contract GrantRoundImplementation is AccessControl, Initializable {
     metaPtr = _metaPtr;
 
     // assign roles
-    _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    _grantRole(DEFAULT_ADMIN_ROLE, _adminRole);
 
     // Assigning round operators
     for (uint256 i = 0; i < _roundOperators.length; ++i) {

--- a/packages/contracts/docs/CHAINS.md
+++ b/packages/contracts/docs/CHAINS.md
@@ -6,14 +6,14 @@ This document lists all the addresses of the contracts that have been deployed o
 
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0x2f97819a05051cC0983988B9E49331E679741309 |
+| goerli  | 0xC4012787FD2242657C19F006D38c55859F0Ca508 |
 
 
 ## GrantRoundImplementation
 
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0xc2B040cdd5fba17779ca2d81c4214d590Db885A9 |
+| goerli  | 0x85387A953d83A149a4f378FA47011C7b6F93d851 |
 
 
 ## BulkVote
@@ -28,7 +28,7 @@ This document lists all the addresses of the contracts that have been deployed o
 This is not the exahustive list but instead just shows example of a round deployed on network
 | Network | Address                                    |
 |---------|--------------------------------------------|
-| goerli  | 0x9e1acfba605339823baeb5edad2eebaf6e1f8363 |
+| goerli  | 0xb42db2ac7f8c1506f2642d398e4762e18667ca9a |
 
 
 

--- a/packages/contracts/scripts/config/round.config.ts
+++ b/packages/contracts/scripts/config/round.config.ts
@@ -9,8 +9,8 @@ type DeployParams = Record<string, RoundParams>;
 
 export const roundParams: DeployParams = {
   goerli: {
-    grantRoundImplementationContract: '0xc2B040cdd5fba17779ca2d81c4214d590Db885A9',
-    grantRoundFactoryContract: '0x2f97819a05051cC0983988B9E49331E679741309',
+    grantRoundImplementationContract: '0x85387A953d83A149a4f378FA47011C7b6F93d851',
+    grantRoundFactoryContract: '0xC4012787FD2242657C19F006D38c55859F0Ca508',
     bulkVoteContract: '0xc76Ea06e2BC6476178e40E2B40bf5C6Bf3c40EF6'
   },
 };


### PR DESCRIPTION
##### Description

Currently the admin role of the grant was set to the factory address 
This PR ensures 
- the caller of the contract is indeed set as the admin 
- GrantContract uses AccessControlEnumerable 

##### Testing

Tested on testnet & documentation has been updated with latest contract

https://goerli.etherscan.io/address/0xb42db2ac7f8c1506f2642d398e4762e18667ca9a#events