### PR TITLE
feat: use subgraph in round list service

### DIFF
--- a/packages/round-manager/src/features/api/services/program.ts
+++ b/packages/round-manager/src/features/api/services/program.ts
@@ -76,8 +76,7 @@ export const programApi = api.injectEndpoints({
     listPrograms: builder.query<Program[], string>({
       queryFn: async (account) => {
         try {
-          account = ethers.utils.getAddress(account)
-
+          // get the subgraph for all programs owned by the given account
           const res = await graphql_fetch(
             `
               query GetPrograms($account: String!) {
@@ -101,7 +100,7 @@ export const programApi = api.injectEndpoints({
                 }
               }
             `,
-            { account: account.toLowerCase() }
+            { account: ethers.utils.getAddress(account).toLowerCase() }
           )
 
           const programs: Program[] = []

--- a/packages/round-manager/src/features/api/services/program.ts
+++ b/packages/round-manager/src/features/api/services/program.ts
@@ -100,7 +100,7 @@ export const programApi = api.injectEndpoints({
                 }
               }
             `,
-            { account: ethers.utils.getAddress(account).toLowerCase() }
+            { account }
           )
 
           const programs: Program[] = []

--- a/packages/round-manager/src/features/api/services/round.ts
+++ b/packages/round-manager/src/features/api/services/round.ts
@@ -104,12 +104,16 @@ export const roundApi = api.injectEndpoints({
           // query the subgraph for all rounds by the given account in the given program
           const res = await graphql_fetch(
             `
-              query GetRounds($account: String!, $programId: String!) {
+              query GetRounds($account: String!, $programId: String) {
                 rounds(where: {
                   accounts_: {
                     address: $account
                   }
-                  program: $programId
+            `
+              +
+                (programId ? `program: $programId` : ``)
+              +
+            `
                 }) {
                   id
                   program
@@ -155,7 +159,7 @@ export const roundApi = api.injectEndpoints({
               roundStartTime: new Date(round.roundStartTime * 1000),
               roundEndTime: new Date(round.roundEndTime * 1000),
               token: round.token,
-              votingStrategy: "",
+              votingStrategy: round.votingStrategy,
               ownedBy: round.program
             })
           }

--- a/packages/round-manager/src/features/api/services/round.ts
+++ b/packages/round-manager/src/features/api/services/round.ts
@@ -110,9 +110,9 @@ export const roundApi = api.injectEndpoints({
                     address: $account
                   }
             `
-              +
-                (programId ? `program: $programId` : ``)
-              +
+            +
+            (programId ? `program: $programId` : ``)
+            +
             `
                 }) {
                   id
@@ -132,10 +132,7 @@ export const roundApi = api.injectEndpoints({
                 }
               }
             `,
-            {
-              account: ethers.utils.getAddress(account).toLowerCase(),
-              programId: programId?.toLowerCase()
-            }
+            { account, programId }
           )
 
           const rounds: Round[] = []

--- a/packages/round-manager/src/features/api/types.ts
+++ b/packages/round-manager/src/features/api/types.ts
@@ -88,7 +88,7 @@ export interface Round {
   /**
    * Metadata of the Round to be stored off-chain
    */
-  metadata?: {
+  roundMetadata?: {
     name: string
   };
   /**

--- a/packages/round-manager/src/features/program/ViewProgramPage.tsx
+++ b/packages/round-manager/src/features/program/ViewProgramPage.tsx
@@ -33,7 +33,7 @@ export default function ViewProgram() {
       <div className="flex-1 min-w-0">
 
         <p className="text-sm mb-1 font-medium text-gray-900">
-          {round.metadata!.name}
+          {round.roundMetadata!.name}
         </p>
 
         <div className="grid sm:grid-cols-3">

--- a/packages/round-manager/src/features/round/RoundDetailForm.tsx
+++ b/packages/round-manager/src/features/round/RoundDetailForm.tsx
@@ -13,7 +13,7 @@ import { Input } from "../common/styles"
 
 
 const ValidationSchema = yup.object().shape({
-  metadata: yup.object({
+  roundMetadata: yup.object({
     name: yup.string()
       .required("This field is required.")
       .min(8, "Round name must be less that 8 characters."),
@@ -66,11 +66,11 @@ export function RoundDetailForm(props: { initialData: any, stepper: any }) {
               <div className="col-span-6 sm:col-span-3">
                 <label htmlFor="name" className="block text-xs font-medium text-gray-700">Round Name</label>
                 <Input
-                  {...register("metadata.name")}
-                  $hasError={errors.metadata?.name}
+                  {...register("roundMetadata.name")}
+                  $hasError={errors.roundMetadata?.name}
                   type="text"
                 />
-                {errors.metadata?.name && <p className="text-sm text-red-600">{errors.metadata?.name?.message}</p>}
+                {errors.roundMetadata?.name && <p className="text-sm text-red-600">{errors.roundMetadata?.name?.message}</p>}
               </div>
             </div>
 

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -14,8 +14,8 @@ import ApplicationsRejected from "./ApplicationsRejected"
 
 export default function ViewRound() {
   const { id } = useParams()
-
   const { account } = useWeb3()
+
   const {
     round,
     isLoading: isRoundsLoading,

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -48,7 +48,7 @@ export default function ViewRound() {
           </Link>
         </div>
         <div className="flow-root">
-          <h1 className="float-left text-[32px] mb-6">{round?.metadata?.name || "..."}</h1>
+          <h1 className="float-left text-[32px] mb-6">{round?.roundMetadata?.name || "..."}</h1>
         </div>
         <hr/>
       </header>


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

This PR uses the subgraph instead of contract interactions to get the list of rounds for a given account/programId

##### Refers/Fixes

closes #150 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
