### PR TITLE
chg: Add QEDK as code owner for contracts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @thelostone-mc @chibie @pragmatriot
+/packages/contracts/ @QEDK


### PR DESCRIPTION
##### Description
Add QEDK as code owner for contracts