### PR TITLE
feat: allow subgraph to be deploy on multiple networks

### DIFF
--- a/packages/graph/.gitignore
+++ b/packages/graph/.gitignore
@@ -1,2 +1,3 @@
 build/
 generated/
+subgraph.yaml

--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -6,14 +6,15 @@ This package holds the subgraph which indexs data with regard the
 - RoundFactory
 - RoundImplementation
 
-The subgraph has been on goerli as a hosted service.
 
-**Entity mapping + Playground**
-https://api.thegraph.com/subgraphs/name/thelostone-mc/program-factory-v0
+#### Deployed Subgraphs
 
-**Playground Link**
-https://thegraph.com/hosted-service/subgraph/thelostone-mc/program-factory-v0?selected=playground
+The following sections document the hosted services where the subgraph is deployed across different networks
 
+| Network        | GITHUB_USER/SUBGRAPH_NAME                 | Playground                                                                             | Query                                                                             |
+|----------------|-------------------------------------------|----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| goerli         | thelostone-mc/program-factory-v0          | https://thegraph.com/hosted-service/subgraph/thelostone-mc/program-factory-v0          | https://api.thegraph.com/subgraphs/name/thelostone-mc/program-factory-v0          |
+| optimism-kovan | thelostone-mc/grants-round-optimism-kovan | https://thegraph.com/hosted-service/subgraph/thelostone-mc/grants-round-optimism-kovan | https://api.thegraph.com/subgraphs/name/thelostone-mc/grants-round-optimism-kovan |
 
 ## Directory Structure
 
@@ -76,7 +77,7 @@ graph auth --product hosted-service <YOUR_API_KEY>
 
 - Deploy Subgraph
 ```shell
-graph deploy --product hosted-service thelostone-mc/program-factory-v0
+graph deploy --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 ```
 
 
@@ -88,5 +89,5 @@ rm -rf generated && rm -rf build &&
     yarn prepare:goerli &&
     graph codegen &&
     graph auth --product hosted-service <YOUR_API_KEY> &&
-    graph deploy --product hosted-service thelostone-mc/program-factory-v0
+    graph deploy --product hosted-service <GITHUB_USER>/<SUBGRAPH_NAME>
 ```

--- a/packages/graph/README.md
+++ b/packages/graph/README.md
@@ -30,7 +30,7 @@ https://thegraph.com/hosted-service/subgraph/thelostone-mc/program-factory-v0?se
 │       ├── implementation.ts   # RoundImplementation event handlers
 │   ├── utils.ts                # useful helper functions
 ├── schema.graphql              # Entity schema
-├── subgraph.yaml               # Subgraph configuration
+├── subgraph.template.yaml      # Subgraph configuration
 ├── tsconfig.json               # Typescript configuration 
 ├── package.json                # Package configuration
 └── .gitignore
@@ -50,6 +50,20 @@ Generate your hosted-service API key on the graph
 rm -rf generated && rm -rf build
 ```
 
+- Generate the `subgraph.yaml` for the network against which you'd like to deploy the subgraph
+
+```shell
+yarn prepare:<NETWORK_TO_DEPLOY_SUBGRAPH>
+```
+
+**Supported Networks**
+
+| network        |
+|----------------|
+| goerli         |
+| optimism-kovan |
+
+
 - Run codegen
 ```shell
 graph codegen
@@ -63,4 +77,16 @@ graph auth --product hosted-service <YOUR_API_KEY>
 - Deploy Subgraph
 ```shell
 graph deploy --product hosted-service thelostone-mc/program-factory-v0
+```
+
+
+Note: If you find yourself wanting to run the entire flow in one command.
+Use this example where we deploy the subgraph on goerli
+
+```shell
+rm -rf generated && rm -rf build &&
+    yarn prepare:goerli &&
+    graph codegen &&
+    graph auth --product hosted-service <YOUR_API_KEY> &&
+    graph deploy --product hosted-service thelostone-mc/program-factory-v0
 ```

--- a/packages/graph/config/goerli.json
+++ b/packages/graph/config/goerli.json
@@ -1,0 +1,6 @@
+{
+  "network": "goerli",
+  "startBlock": 7015700,
+  "programFactoryAddress": "0xAd732aB847d20EdfC48A6d9B256f35D756381C52",
+  "roundFactoryAddress": "0x515594eeB37A6D5815F4c860454cD4FD87539978"
+}

--- a/packages/graph/config/optimism-kovan.json
+++ b/packages/graph/config/optimism-kovan.json
@@ -1,0 +1,6 @@
+{
+  "network": "optimism-kovan",
+  "startBlock": 280000,
+  "programFactoryAddress": "0xb19589C32351EC32652BAb386b61443b741B678a",
+  "roundFactoryAddress": "0xbB8f276FE1D52a38FbED8845bCefb9A23138Af92"
+}

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -12,6 +12,8 @@
   },
   "homepage": "https://github.com/gitcoinco/grants-round#readme",
   "scripts": {
+    "prepare:goerli": "mustache config/goerli.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:optimism-kovan": "mustache config/optimism-kovan.json subgraph.template.yaml > subgraph.yaml",
     "codegen": "graph codegen",
     "build": "graph build",
     "deploy": "graph deploy --node https://api.thegraph.com/deploy/ thelostone-mc/program-factory",
@@ -26,6 +28,7 @@
     "@openzeppelin/subgraphs": "^0.1.8"
   },
   "devDependencies": {
-    "matchstick-as": "^0.5.0"
+    "matchstick-as": "^0.5.0",
+    "mustache": "^4.2.0"
   }
 }

--- a/packages/graph/subgraph.template.yaml
+++ b/packages/graph/subgraph.template.yaml
@@ -9,11 +9,11 @@ dataSources:
   # ProgramFactory
   - kind: ethereum/contract
     name: Program
-    network: goerli
+    network: {{ network }}
     source:
-      address: "0xAd732aB847d20EdfC48A6d9B256f35D756381C52"
+      address: '{{ programFactoryAddress }}'
       abi: ProgramFactory
-      startBlock: 7015700 
+      startBlock: {{ startBlock }} 
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -33,11 +33,11 @@ dataSources:
   # RoundFactory
   - kind: ethereum/contract
     name: Round
-    network: goerli
+    network: {{ network }}
     source:
-      address: "0x515594eeB37A6D5815F4c860454cD4FD87539978"
+      address: '{{ roundFactoryAddress }}'
       abi: RoundFactory
-      startBlock: 7015700 
+      startBlock: {{ startBlock }} 
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -58,7 +58,7 @@ templates:
   # ProgramImplementation AccessControl
   - kind: ethereum/contract
     name: ProgramImplementation
-    network: goerli
+    network: {{ network }}
     source:
       abi: ProgramImplementation
     mapping:
@@ -80,7 +80,7 @@ templates:
   # RoundImplementation AccessControl
   - kind: ethereum/contract
     name: RoundImplementation
-    network: goerli
+    network: {{ network }}
     source:
       abi: RoundImplementation
     mapping:

--- a/packages/graph/yarn.lock
+++ b/packages/graph/yarn.lock
@@ -2453,6 +2453,11 @@ murmurhash3js@^3.0.1:
   resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
   integrity sha512-KL8QYUaxq7kUbcl0Yto51rMcYt7E/4N4BG3/c96Iqw1PQrTRspu8Cpx4TZ4Nunib1d4bEkIH3gjCYlP2RLBdow==
 
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"


### PR DESCRIPTION
### Description

- update .gitignore to include subgraph.yaml
- replace subgraph.yaml with subgraph.template.yaml
- add mustache to generate yaml from template
- update readme doc
- add config for networks



##### Refers/Fixes

closes #158 

##### Testing

| Network        | GITHUB_USER/SUBGRAPH_NAME                 | Playground                                                                             | Query                                                                             |
|----------------|-------------------------------------------|----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
| goerli         | thelostone-mc/program-factory-v0          | https://thegraph.com/hosted-service/subgraph/thelostone-mc/program-factory-v0          | https://api.thegraph.com/subgraphs/name/thelostone-mc/program-factory-v0          |
| optimism-kovan | thelostone-mc/grants-round-optimism-kovan | https://thegraph.com/hosted-service/subgraph/thelostone-mc/grants-round-optimism-kovan | https://api.thegraph.com/subgraphs/name/thelostone-mc/grants-round-optimism-kovan |

