### PR TITLE
chore: update project id lookup in graph

### DIFF
--- a/packages/graph/docs/Round.md
+++ b/packages/graph/docs/Round.md
@@ -126,7 +126,7 @@ You can do this by two means :
 ```graphql
 {
   rounds(where:{
-    id: "0x707F12906E028dE672424d600c9C69460dcD2295"
+    id: "0xd96222ec011cded90be74969d0cffdf4247fae1b"
   }) {
     id
     projects {

--- a/packages/graph/docs/Round.md
+++ b/packages/graph/docs/Round.md
@@ -131,6 +131,7 @@ You can do this by two means :
     id
     projects {
       id
+      project
       status
       payoutAddress
       metaPtr {

--- a/packages/graph/schema.graphql
+++ b/packages/graph/schema.graphql
@@ -80,6 +80,7 @@ type RoundAccount @entity {
 # id: round.toHex()-project.toHex()
 type RoundProject @entity {
   id: ID!
+  project: String!
   status: String!
   metaPtr: MetaPtr!
   round: Round!

--- a/packages/graph/src/round/implementation.ts
+++ b/packages/graph/src/round/implementation.ts
@@ -169,7 +169,7 @@ export function handleProjectsMetaPtrUpdated(event: ProjectsMetaPtrUpdatedEvent)
 
     const _id =  _project.get("id")
     if (!_id) continue;
-    const projectId = [_id.toString().toLowerCase(), _round].join('-');
+    const projectId = _id.toString().toLowerCase();
 
     // load project entity
     let project = RoundProject.load(projectId);

--- a/packages/graph/src/round/implementation.ts
+++ b/packages/graph/src/round/implementation.ts
@@ -122,6 +122,7 @@ export function handleNewProjectApplication(event: NewProjectApplicationEvent): 
   project = project == null ? new RoundProject(projectId) : project;
 
   //  RoundProject
+  project.project = _project.toString();
   project.round = round.id;
   project.metaPtr = metaPtr.id;
   project.status = "PENDING";


### PR DESCRIPTION
##### Description

The graph sets a project application to a round by prefixing the round id to the given project id.
The frontend already sends it with the round id prefixed
This means we can avoid the prefix operation on the graph 

**Expected ID from graph:** 

`0x000000000000000000000000500df079bebe24a9f6ffa2c70fb58000a4722784-0xd96222ec011cded90be74969d0cffdf4247fae1b`

**What graph was doing:** 
`0x000000000000000000000000500df079bebe24a9f6ffa2c70fb58000a4722784-0xd96222ec011cded90be74969d0cffdf4247fae1b-0xd96222ec011cded90be74969d0cffdf4247fae1b`


Additionally, the subgraph schema has been updated to include the project ID as a part of the schema to enable easy quering  


##### Testing

IPFS link: 
https://gitcoin.mypinata.cloud/ipfs/bafkreibmenkpeyaezovxutlqlfsybn7cfaa43zd2zauuywadzsnvvlapb4

Query: 
```
{
  rounds(where:{
    id: "0xd96222ec011cded90be74969d0cffdf4247fae1b"
  }) {
    id
    projects {
      id
      status
      payoutAddress
      metaPtr {
        protocol
        pointer
      }
    }
  }
}
```
**Query:** 
https://thegraph.com/hosted-service/subgraph/thelostone-mc/program-factory-v0?selected=playground
