### PR TITLE
fix: fix a bug where user was unable to approve/reject some applications

### DIFF
--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -52,10 +52,10 @@ export default function ApplicationsReceived({
 
   const toggleSelection = (id: string, status: string) => {
     const newState = selected?.map((obj: any) => {
-      status = obj.status === status ? "PENDING" : status
+      const newStatus = obj.status === status ? "PENDING" : status
 
       if (obj.id === id) {
-        return { ...obj, status }
+        return { ...obj, status: newStatus }
       }
 
       return obj

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
@@ -128,6 +128,18 @@ describe("<ApplicationsReceived />", () => {
       });
     });
 
+    it("should approve individual applications independently", () => {
+      renderWrapped(<ApplicationsReceived bulkSelect={true} />)
+
+      const firstApproveButton = screen.queryAllByTestId("approve-button")[0]
+      fireEvent.click(firstApproveButton)
+      expect(firstApproveButton).toHaveClass("bg-teal-400 text-grey-500")
+
+      const secondApproveButton = screen.queryAllByTestId("approve-button")[1]
+      fireEvent.click(secondApproveButton)
+      expect(secondApproveButton).toHaveClass("bg-teal-400 text-grey-500")
+    });
+
   });
   describe("when bulkSelect is false", () => {
     it("does not render approve and reject buttons on each card", () => {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

<!-- Describe your changes here. -->
There is a weird bug where after you approve one application, you aren't able to approve a subsequent application.

**Steps to reproduce:**
1. Go to a round with applications ([example](https://rmgitcoin.on.fleek.co/#/round/0xb91fec0b68f39cbfdd75e4f08042c60724e1bd3b))
2. Click "Select" button to begin bulk approval/rejection process
3. Click "Approve" on the first application
4. Click "Approve" on the second application

**Expected behavior:**
Both applications should display as "approved"

**Actual behavior:**
Second application does not display as "approved"

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->
related to #251

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
Added a small regression test for the approve case
