### PR TITLE
fix: stick bulk approval continue button to bottom

### DIFF
--- a/packages/round-manager/src/features/api/services/grantApplication.ts
+++ b/packages/round-manager/src/features/api/services/grantApplication.ts
@@ -164,19 +164,16 @@ export const grantApplicationApi = api.injectEndpoints({
         try {
           const ipfsHash = await updateApplicationList([application], roundId, provider)
 
-          // update projects meta pointer in round implementation contract
-          application.projectsMetaPtr = {
-            protocol: 1,
-            pointer: ipfsHash
-          }
-
           const roundImplementation = new ethers.Contract(
             roundId,
             roundImplementationContract.abi,
             signer
           )
 
-          let tx = await roundImplementation.updateProjectsMetaPtr(application.projectsMetaPtr)
+          let tx = await roundImplementation.updateProjectsMetaPtr({
+            protocol: 1,
+            pointer: ipfsHash
+          })
 
           await tx.wait() // wait for transaction receipt
 
@@ -196,7 +193,7 @@ export const grantApplicationApi = api.injectEndpoints({
     >({
       queryFn: async ({ roundId, applications, signer, provider }) => {
         try {
-          let ipfsHash = await updateApplicationList(applications, roundId, provider)
+          const ipfsHash = await updateApplicationList(applications, roundId, provider)
 
           // update projects meta pointer in round implementation contract
           const roundImplementation = new ethers.Contract(

--- a/packages/round-manager/src/features/common/ConfirmationModal.tsx
+++ b/packages/round-manager/src/features/common/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useRef, useState } from "react"
+import React, { Fragment, useRef } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import { Button } from "./styles";
 
@@ -10,6 +10,7 @@ interface ModalProps {
   cancelButtonText?: string;
   confirmButtonText?: string;
   isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   confirmButtonAction: () => void;
   cancelButtonAction?: () => void;
 }
@@ -21,22 +22,18 @@ export default function ConfirmationModal(
     cancelButtonText = "Cancel",
     confirmButtonText = "Confirm",
     bodyStyled = <></>,
-    cancelButtonAction = () => setOpen(false),
+    isOpen = false,
+    setIsOpen = () => {},
+    cancelButtonAction = () => setIsOpen(false),
     ...props
   }: ModalProps
 ) {
 
-  const [open, setOpen] = useState(false)
-
   const cancelButtonRef = useRef(null)
 
-  useEffect(() => {
-    setOpen(props.isOpen)
-  }, [props.isOpen])
-
   return (
-    <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" initialFocus={cancelButtonRef} onClose={setOpen} data-testid="confirm-modal"
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-10" initialFocus={cancelButtonRef} onClose={setIsOpen} data-testid="confirm-modal"
       >
         <Transition.Child
           as={Fragment}

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -27,7 +27,6 @@ interface ApplicationsReceivedProps {
 export default function ApplicationsReceived({
   bulkSelect = false,
   setBulkSelect = () => {},
-  ...props
 }: ApplicationsReceivedProps) {
   const [openModal, setOpenModal] = useState(false)
 
@@ -171,7 +170,7 @@ export default function ApplicationsReceived({
       </CardsContainer>
       {selected && selected?.filter(obj => obj.status !== "PENDING").length > 0 && (
         <>
-          <div className="absolute w-full left-0 bottom-0 bg-white">
+          <div className="fixed w-full left-0 bottom-0 bg-white">
             <hr />
             <div className="flex justify-end items-center py-5 pr-20">
               <span className="text-grey-400 text-sm mr-6">
@@ -194,7 +193,7 @@ export default function ApplicationsReceived({
             bodyStyled={
               <>
                 <div className="flex my-8 gap-16 justify-center items-center text-center">
-                  <div className="grid gap-2">
+                  <div className="grid gap-2" data-testid="approved-applications-count">
                     <i className="flex justify-center">
                       <CheckIcon className="bg-teal-400 text-grey-500 rounded-full h-6 w-6 p-1" aria-hidden="true" />
                     </i>
@@ -202,7 +201,7 @@ export default function ApplicationsReceived({
                     <span className="text-grey-500 font-semibold">{selected?.filter(obj => obj.status === "APPROVED").length}</span>
                   </div>
                   <span className="text-4xl font-thin">|</span>
-                  <div className="grid gap-2">
+                  <div className="grid gap-2" data-testid="rejected-applications-count">
                     <i className="flex justify-center">
                       <XIcon className="bg-pink-500 text-white rounded-full h-6 w-6 p-1" aria-hidden="true" />
                     </i>
@@ -216,6 +215,7 @@ export default function ApplicationsReceived({
             confirmButtonAction={handleBulkReview}
             cancelButtonAction={() => setOpenModal(false)}
             isOpen={openModal}
+            setIsOpen={setOpenModal}
           />
         </>
       )}

--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -145,6 +145,7 @@ export default function ViewApplicationPage() {
             confirmButtonAction={handleUpdateGrantApplication}
             cancelButtonAction={handleCancelModal}
             isOpen={openModal}
+            setIsOpen={setOpenModal}
           />
         </header>
 

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -16,6 +16,7 @@ import tw from "tailwind-styled-components";
 import { Button } from "../common/styles"
 
 
+
 export default function ViewRoundPage() {
   const [bulkSelect, setBulkSelect] = useState(false)
 
@@ -67,7 +68,7 @@ export default function ViewRoundPage() {
   return (
     <>
       <Navbar />
-      <div className="flex flex-col w-screen h-screen mx-0">
+      <div className="flex flex-col w-screen mx-0">
         <header className="border-b bg-grey-150 px-3 md:px-20 py-6">
           <div className="text-grey-400 font-bold text-sm flex flex-row items-center gap-3">
             <Link to={`/`}>

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
@@ -1,6 +1,9 @@
-import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react"
+import { fireEvent, screen, waitForElementToBeRemoved, within } from "@testing-library/react"
 import ApplicationsReceived from "../ApplicationsReceived"
-import { useBulkUpdateGrantApplicationsMutation, useListGrantApplicationsQuery } from "../../api/services/grantApplication"
+import {
+  useBulkUpdateGrantApplicationsMutation,
+  useListGrantApplicationsQuery,
+} from "../../api/services/grantApplication"
 import { makeGrantApplicationData, renderWrapped } from "../../../test-utils"
 
 jest.mock("../../api/services/grantApplication");
@@ -169,7 +172,7 @@ describe("<ApplicationsReceived />", () => {
         expect(screen.getByText(/You have selected 2 Grant Applications/i)).toBeInTheDocument();
       })
 
-      it("opens the confirmation modal with the correct number of selected applications when the continue button is clicked", async () => {
+      it("opens the confirmation modal when the continue button is clicked", async () => {
         renderWrapped(<ApplicationsReceived bulkSelect={true} />)
 
         const approveButton = screen.queryAllByTestId("approve-button")[0]
@@ -181,6 +184,25 @@ describe("<ApplicationsReceived />", () => {
         fireEvent.click(continueButton)
 
         expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
+      })
+
+      it("shows the correct number of approved and rejected applications in the confirmation modal", async () => {
+        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
+
+        fireEvent.click(screen.queryAllByTestId("approve-button")[0])
+        fireEvent.click(screen.queryAllByTestId("reject-button")[1])
+        fireEvent.click(screen.queryAllByTestId("approve-button")[2])
+
+        const continueButton = screen.getByRole('button', {
+          name: /Continue/i
+        });
+        fireEvent.click(continueButton)
+
+        const approvedApplicationsCount = screen.getByTestId("approved-applications-count")
+        const rejectedApplicationsCount = screen.getByTestId("rejected-applications-count")
+
+        within(approvedApplicationsCount).getByText(/2/)
+        within(rejectedApplicationsCount).getByText(/1/)
       })
 
       it("calls bulkUpdateGrantApplications when confirm button is clicked on the modal", async () => {


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

- stick bulk approval continue button to bottom
- added test to verify bulk approval confirmation modal content
- confirmation modal uses isOpen/setIsOpen props instead of managing internal state
- inline ipfsHash in updateProjectsMetaPtr in updateGrantApplication api

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->
closes #252

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
![Screen Shot 2022-08-16 at 11 21 59 AM](https://user-images.githubusercontent.com/62616399/184929877-b5fc8f13-3869-4a8c-8493-273efb79b689.png)
![Screen Shot 2022-08-16 at 11 22 04 AM](https://user-images.githubusercontent.com/62616399/184929882-afe2a445-8c49-4d17-8adf-a5cc8c2a2410.png)
