### PR TITLE
chore: add link to staging + live env

### DIFF
--- a/packages/round-manager/README.md
+++ b/packages/round-manager/README.md
@@ -52,3 +52,18 @@ Since all the data is decentralized stored, there might be PII (Personally ident
 ### Development
 
 To contribute to this project, fork the project and follow the instructions at [DEV.md](docs/DEV.md)
+
+### Hosting
+
+All the frontend dApps are currently hosted presently via [fleek.co](https://fleek.co/).
+
+Documented below are the environments along with the URL.
+
+Note: Live Deployment should always happen by raising a PR from `main` to `release`  
+
+**round-manager**
+
+| Env     | Git Branch | URL                               |
+|---------|------------|-----------------------------------|
+| STAGING | main       | https://rmgitcoin.on.fleek.co/    |
+| LIVE    | release    | https://round-manager.gitcoin.co/ |


### PR DESCRIPTION
##### Description

| Env     | Git Branch | URL                               |
|---------|------------|-----------------------------------|
| STAGING | main       | https://rmgitcoin.on.fleek.co/    |
| LIVE    | release    | https://round-manager.gitcoin.co/ |

##### Refers/Fixes

fixes https://github.com/gitcoinco/grants-round/issues/241

##### Testing

Links are documented above