### PR TITLE
fix: make bulk select icons clickable

### DIFF
--- a/packages/round-manager/src/app/wagmi.ts
+++ b/packages/round-manager/src/app/wagmi.ts
@@ -1,6 +1,6 @@
-import '@rainbow-me/rainbowkit/styles.css'
+import "@rainbow-me/rainbowkit/styles.css"
 
-import { getDefaultWallets } from '@rainbow-me/rainbowkit'
+import { getDefaultWallets } from "@rainbow-me/rainbowkit"
 
 import {
   createClient,
@@ -26,7 +26,7 @@ export const { chains, provider, webSocketProvider } = configureChains(
 const { connectors } = getDefaultWallets({
   appName: 'Gitcoin Round Manager',
   chains
-});
+})
 
 export const client = createClient({
   autoConnect: true,

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -26,7 +26,7 @@ interface ApplicationsReceivedProps {
 
 export default function ApplicationsReceived({
   bulkSelect = false,
-  setBulkSelect = () => {},
+  setBulkSelect = () => { },
 }: ApplicationsReceivedProps) {
   const [openModal, setOpenModal] = useState(false)
 
@@ -95,63 +95,63 @@ export default function ApplicationsReceived({
     <div>
       <CardsContainer>
         {isSuccess && data?.map((application, index) => (
-          <Link to={`/round/${id}/application/${application.id}`}>
-            <BasicCard key={index} className="application-card" data-testid="application-card">
-              <CardHeader>
-                {bulkSelect && (
-                  <div className="absolute flex gap-2 translate-x-[206px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
-                    <Button
-                      type="button"
-                      $variant="solid"
-                      className={
-                        `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "APPROVED"
-                          ? "bg-teal-400 text-grey-500" : "bg-grey-500 text-white"}`
-                      }
-                      onClick={() => toggleSelection(application.id, "APPROVED")}
-                      data-testid="approve-button"
-                    >
-                      <CheckIcon aria-hidden="true" />
-                    </Button>
-                    <Button
-                      type="button"
-                      $variant="solid"
-                      className={
-                        `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "REJECTED"
-                          ? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
-                      }
-                      onClick={() => toggleSelection(application.id, "REJECTED")}
-                      data-testid="reject-button"
-                    >
-                      <XIcon aria-hidden="true" />
-                    </Button>
-                  </div>)}
+          <BasicCard key={index} className="application-card" data-testid="application-card">
+            <CardHeader>
+              {bulkSelect && (
+                <div className="absolute flex gap-2 translate-x-[206px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
+                  <Button
+                    type="button"
+                    $variant="solid"
+                    className={
+                      `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "APPROVED"
+                        ? "bg-teal-400 text-grey-500" : "bg-grey-500 text-white"}`
+                    }
+                    onClick={() => toggleSelection(application.id, "APPROVED")}
+                    data-testid="approve-button"
+                  >
+                    <CheckIcon aria-hidden="true" />
+                  </Button>
+                  <Button
+                    type="button"
+                    $variant="solid"
+                    className={
+                      `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "REJECTED"
+                        ? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
+                    }
+                    onClick={() => toggleSelection(application.id, "REJECTED")}
+                    data-testid="reject-button"
+                  >
+                    <XIcon aria-hidden="true" />
+                  </Button>
+                </div>)}
+              <div>
                 <div>
-                  <div>
-                    <img
-                      className="h-[120px] w-full object-cover rounded-t"
-                      src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.bannerImg}`}
-                      alt=""
-                    />
-                  </div>
-                  <div className="pl-4">
-                    <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
-                      <div className="flex">
-                        <img
-                          className="h-12 w-12 rounded-full ring-4 ring-white bg-white"
-                          src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.logoImg}`}
-                          alt=""
-                        />
-                      </div>
+                  <img
+                    className="h-[120px] w-full object-cover rounded-t"
+                    src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.bannerImg}`}
+                    alt=""
+                  />
+                </div>
+                <div className="pl-4">
+                  <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
+                    <div className="flex">
+                      <img
+                        className="h-12 w-12 rounded-full ring-4 ring-white bg-white"
+                        src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.logoImg}`}
+                        alt=""
+                      />
                     </div>
                   </div>
                 </div>
-              </CardHeader>
+              </div>
+            </CardHeader>
+            <Link to={`/round/${id}/application/${application.id}`}>
               <CardContent>
                 <CardTitle>{application.project!.title}</CardTitle>
                 <CardDescription>{application.project!.description}</CardDescription>
               </CardContent>
-            </BasicCard>
-          </Link>
+            </Link>
+          </BasicCard>
         ))}
         {isLoading &&
           <Spinner text="Fetching Grant Applications" />


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

Bulk select was no longer possible as every area of the application card is linked to the detail page. This PR makes only the card content area clickable

##### Refers/Fixes

refers #280 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
