### PR TITLE
feat: add datadog monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # grants-round
 
-This repository contains packages needed for a user to 
+This repository contains packages needed for a user to
 - Create & Manage Rounds
-- Explore available Rounds 
+- Explore available Rounds
 - Vote for Projects within a Round
 
 Project Maintained via  : `lerna`
@@ -18,11 +18,11 @@ Build Tool              : `yarn`
 │   ├── graph                   # graph which indexes data from contracts
 │   ├── round-manager           # react-frontend for round-manager
 │   ├── round-explorer          # react-frontend for round-explorer
-├── docs                        # useful documentation 
+├── docs                        # useful documentation
 ├── lerna.json                  # lerna config
 ├── package.json                # root package configuration
 └── README.md
-``` 
+```
 
 ## Packages
 
@@ -45,9 +45,9 @@ To contribute to this project, fork the project and follow the instructions at [
 
 This is built and maintained using [hardhat](https://hardhat.org)
 
-### graph 
+### graph
 
-This package holds the subgraph which indexs data with regard the 
+This package holds the subgraph which indexs data with regard the
 - ProgramFactory
 - ProgramImplementation
 - RoundFactory
@@ -57,7 +57,7 @@ More information can be found within the [graph package](packages/graph)
 
 ### round-manager
 
-This package serves the app which holds all the features w.r.t to 
+This package serves the app which holds all the features w.r.t to
 
 - creating a program
 - maintaing a program
@@ -73,7 +73,7 @@ To contribute to this project, fork the project and follow the instructions at [
 
 ### round-explorer
 
-This package serves the app which holds all the features w.r.t to 
+This package serves the app which holds all the features w.r.t to
 
 - exploring a round
 - voting for a project
@@ -84,3 +84,18 @@ More information can be found within the [round-explorer package](packages/round
 ##### Development
 
 To contribute to this project, fork the project and follow the instructions at [DEV.md](packages/round-explorer/docs/DEV.md)
+
+##### Hosting
+
+All the frontend dApps are currently hosted presently via [fleek.co](https://fleek.co/).
+
+Documented below are the environments along with the URL.
+
+Note: Live Deployment should always happen by raising a PR from `main` to `release`
+
+**round-manager**
+
+| Env     | Git Branch | URL                               |
+|---------|------------|-----------------------------------|
+| STAGING | main       | https://rmgitcoin.on.fleek.co/    |
+| LIVE    | release    | https://round-manager.gitcoin.co/ |

--- a/packages/round-manager/.env.sample
+++ b/packages/round-manager/.env.sample
@@ -9,3 +9,9 @@ REACT_APP_SUBGRAPH_OPTIMISM_MAINNET_API=################
 
 # Ethereum Providers
 REACT_APP_INFURA_ID=######################
+
+# Datadog Monitoring
+REACT_APP_DATADOG_APPLICATION_ID=######################
+REACT_APP_DATADOG_CLIENT_TOKEN=######################
+REACT_APP_DATADOG_SERVICE=######################
+REACT_APP_DATADOG_SITE=######################

--- a/packages/round-manager/README.md
+++ b/packages/round-manager/README.md
@@ -11,6 +11,13 @@ This package is meant to be used by the round operators
 It relies on the contracts deployed from the [contracts](../contracts) package.
 Indexed data can be queried by the graphs deployed from the [graph](../graph) package.
 
+## Live Links
+
+| Env     | Git Branch | URL                               |
+|---------|------------|-----------------------------------|
+| STAGING | main       | https://rmgitcoin.on.fleek.co/    |
+| LIVE    | release    | https://round-manager.gitcoin.co/ |
+
 ## Directory Structure 
 
 ```
@@ -53,17 +60,6 @@ Since all the data is decentralized stored, there might be PII (Personally ident
 
 To contribute to this project, fork the project and follow the instructions at [DEV.md](docs/DEV.md)
 
-### Hosting
+### Monitoring
 
-All the frontend dApps are currently hosted presently via [fleek.co](https://fleek.co/).
-
-Documented below are the environments along with the URL.
-
-Note: Live Deployment should always happen by raising a PR from `main` to `release`  
-
-**round-manager**
-
-| Env     | Git Branch | URL                               |
-|---------|------------|-----------------------------------|
-| STAGING | main       | https://rmgitcoin.on.fleek.co/    |
-| LIVE    | release    | https://round-manager.gitcoin.co/ |
+To setup monitoring for this project, follow the instructions at [MONITORING.md](docs/MONITORING.md)

--- a/packages/round-manager/docs/MONITORING.md
+++ b/packages/round-manager/docs/MONITORING.md
@@ -1,0 +1,40 @@
+# Monitoring
+
+round-manager relies datadog's
+- Datadog Real User Monitoring (RUM) : [@datadog/browser-rum](https://www.npmjs.com/package/@datadog/browser-rum)
+- Datadog Browser Logs : [@datadog/browser-logs](https://www.npmjs.com/package/@datadog/browser-logs)
+
+
+## Setup
+
+Ensure the `.env` variables are populated.
+
+```
+REACT_APP_DATADOG_APPLICATION_ID=######################
+REACT_APP_DATADOG_CLIENT_TOKEN=######################
+REACT_APP_DATADOG_SERVICE=######################
+REACT_APP_DATADOG_SITE=######################
+```
+ 
+These can be configured from your datadog account and you can customize the collection information over at [datadog.tsx](../src/datadog.tsx)
+
+## Logging
+
+When a new route is create, ensure you add the following to make the debugging easier.
+
+```javascript
+import { datadogLogs } from "@datadog/browser-logs"
+
+
+datadogLogs.logger.info(`====> Route: {ADD_ROUTE_PATH}`)
+datadogLogs.logger.info(`====> URL: ${window.location.href}`)
+```
+
+To log exceptions errors in datadog. Add logs in the following manner at possible failure points.
+
+```javascript
+import { datadogRum } from "@datadog/browser-rum";
+
+
+datadogRum.addError(e, { provider: providerId });
+```

--- a/packages/round-manager/package.json
+++ b/packages/round-manager/package.json
@@ -9,6 +9,8 @@
   },
   "dependencies": {
     "@craco/craco": "^6.4.3",
+    "@datadog/browser-logs": "^4.17.1",
+    "@datadog/browser-rum": "^4.17.1",
     "@headlessui/react": "^1.6.6",
     "@heroicons/react": "^1.0.6",
     "@hookform/resolvers": "^2.9.2",

--- a/packages/round-manager/src/datadog.tsx
+++ b/packages/round-manager/src/datadog.tsx
@@ -1,0 +1,33 @@
+import { datadogRum } from "@datadog/browser-rum";
+import { datadogLogs } from "@datadog/browser-logs";
+
+/**
+ * Initialize datadog at a global level
+ *  - Datadog Real User Monitoring (RUM) : https://www.npmjs.com/package/@datadog/browser-rum
+ *  - Datadog Brower Logs : https://www.npmjs.com/package/@datadog/browser-logs
+ */
+export const initDatadog = () => {
+  
+  // Init datadog-rum
+  datadogRum.init({
+    applicationId: process.env.REACT_APP_DATADOG_APPLICATION_ID || "",
+    clientToken: process.env.REACT_APP_DATADOG_CLIENT_TOKEN || "",
+    site:  process.env.REACT_APP_DATADOG_SITE || "datadoghq.eu",
+    service: process.env.REACT_APP_DATADOG_SERVICE || "round-manager-staging",
+    // Specify a version number to identify the deployed version of your application in Datadog
+    // version: '1.0.0',
+    sampleRate: 100,
+    premiumSampleRate: 100,
+    trackInteractions: true,
+    defaultPrivacyLevel: "mask-user-input",
+  });
+
+  // Init datadog-logs
+  datadogLogs.init({
+    clientToken: process.env.REACT_APP_DATADOG_CLIENT_TOKEN || "",
+    site: "datadoghq.eu",
+    forwardErrorsToLogs: true,
+    sampleRate: 100,
+    service: "round-manager",
+  });
+};

--- a/packages/round-manager/src/features/common/NotFoundPage.tsx
+++ b/packages/round-manager/src/features/common/NotFoundPage.tsx
@@ -3,8 +3,12 @@ import Navbar from "./Navbar"
 import Footer from "./Footer"
 import { Button } from "../common/styles"
 import { ReactComponent as NotFoundBanner } from "../../assets/404.svg"
+import { datadogLogs } from "@datadog/browser-logs"
 
 export default function NotFoundPage() {
+
+  datadogLogs.logger.info(`====> Route: NotFound`)
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`)
 
   return (
     <>

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -10,6 +10,7 @@ import { Input, Button } from "../common/styles"
 import Navbar from "../common/Navbar"
 import Footer from "../common/Footer"
 import ProgressModal from "../common/ProgressModal"
+import { datadogLogs } from "@datadog/browser-logs"
 
 
 type FormData = {
@@ -18,6 +19,9 @@ type FormData = {
 }
 
 export default function CreateProgram() {
+  datadogLogs.logger.info(`====> Route: ${window.location.href}`)
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`)
+
   const [openProgressModal, setOpenProgressModal] = useState(false)
   const { address, chain, signer } = useWallet()
 

--- a/packages/round-manager/src/features/program/ListProgramPage.tsx
+++ b/packages/round-manager/src/features/program/ListProgramPage.tsx
@@ -21,6 +21,7 @@ import {
 } from "../common/styles"
 import { ReactComponent as Banner } from "../../assets/programs/city-voxel.svg";
 import Footer from "../common/Footer";
+import { datadogLogs } from "@datadog/browser-logs"
 
 interface ProgramCardProps {
   floatingIcon: JSX.Element,
@@ -65,6 +66,11 @@ const startAProgramCard = <Link to="/program/create">
 </Link>
 
 function ListPrograms() {
+
+  datadogLogs.logger.info('====> Route: /')
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`)
+
+
   const { address, provider } = useWallet()
   const {
     data: programs,

--- a/packages/round-manager/src/features/program/ViewProgramPage.tsx
+++ b/packages/round-manager/src/features/program/ViewProgramPage.tsx
@@ -9,9 +9,13 @@ import { useListRoundsQuery } from "../api/services/round"
 import Navbar from "../common/Navbar"
 import Footer from "../common/Footer"
 import { abbreviateAddress } from "../api/utils"
+import { datadogLogs } from "@datadog/browser-logs"
 
 export default function ViewProgram() {
-  
+  datadogLogs.logger.info('====> Route: /program/:id')
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`)
+
+
   const { id } = useParams()
 
   const { address, provider } = useWallet()

--- a/packages/round-manager/src/features/round/CreateRoundPage.tsx
+++ b/packages/round-manager/src/features/round/CreateRoundPage.tsx
@@ -10,9 +10,13 @@ import { RoundApplicationForm } from "./RoundApplicationForm"
 import { Button } from "../common/styles"
 import Navbar from "../common/Navbar"
 import Footer from "../common/Footer"
-
+import { datadogLogs } from "@datadog/browser-logs"
 
 export default function CreateRound() {
+
+  datadogLogs.logger.info('====> Route: /round/create')
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`)
+
   const { address, provider } = useWallet()
   const search = useLocation().search
   const programId = (new URLSearchParams(search)).get("programId")

--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -13,11 +13,16 @@ import { Button } from "../common/styles"
 import { ReactComponent as TwitterIcon } from "../../assets/twitter-logo.svg"
 import { ReactComponent as GithubIcon } from "../../assets/github-logo.svg"
 import Footer from "../common/Footer"
+import { datadogLogs } from "@datadog/browser-logs"
 
 
 type ApplicationStatus = "APPROVED" | "REJECTED"
 
 export default function ViewApplicationPage() {
+
+  datadogLogs.logger.info('====> Route: /program/create')
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`)
+
   const [reviewDecision, setReviewDecision] = useState<ApplicationStatus | undefined>(undefined)
   const [openModal, setOpenModal] = useState(false)
 

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -14,10 +14,14 @@ import Footer from "../common/Footer"
 import { useListGrantApplicationsQuery } from "../api/services/grantApplication";
 import tw from "tailwind-styled-components";
 import { Button } from "../common/styles"
-
+import { datadogLogs } from "@datadog/browser-logs"
 
 
 export default function ViewRoundPage() {
+
+  datadogLogs.logger.info('====> Route: /round/create')
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`)
+
   const [bulkSelect, setBulkSelect] = useState(false)
 
   const { id } = useParams()

--- a/packages/round-manager/src/index.tsx
+++ b/packages/round-manager/src/index.tsx
@@ -4,6 +4,8 @@ import { Provider } from "react-redux"
 import { ReduxRouter } from "@lagunovsky/redux-react-router"
 import { Route, Routes } from "react-router-dom"
 import { WagmiConfig } from "wagmi"
+import { RainbowKitProvider } from '@rainbow-me/rainbowkit'
+import { initDatadog } from "./datadog"
 
 import { store } from "./app/store"
 import { chains, client as WagmiClient } from "./app/wagmi"
@@ -22,9 +24,9 @@ import ViewProgram from "./features/program/ViewProgramPage"
 import ViewRoundPage from "./features/round/ViewRoundPage"
 import ViewApplication from "./features/round/ViewApplicationPage"
 import NotFound from "./features/common/NotFoundPage"
-import {
-  RainbowKitProvider,
-} from '@rainbow-me/rainbowkit';
+
+// Initialize datadog
+initDatadog()
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/packages/round-manager/yarn.lock
+++ b/packages/round-manager/yarn.lock
@@ -1274,6 +1274,33 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-1.0.0.tgz#91c560df2ed8d9700e4c7ed4ac21a3a322c9d975"
   integrity sha512-RkYG5KiGNX0fJ5YoI0f4Wfq2Yo74D25Hru4fxTOioYdQvHBxcrrtTTyT5Ozzh2ejcNrhFy7IEts2WyEY7yi5yw==
 
+"@datadog/browser-core@4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-core/-/browser-core-4.17.1.tgz#0f18aa8a902e9b5f2cd25692f639c77143788e12"
+  integrity sha512-M34aI8PhRP7K7FkULI7B2Qeoy+V93wlHd5O7s5Q2Y2PAhkjpNWpUMBtmvIE77wCx/VaZxGlwaDWL+Oj9vliW0g==
+
+"@datadog/browser-logs@^4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-logs/-/browser-logs-4.17.1.tgz#5aedafd15d74781bdd09cce34ebeb789bfa8a859"
+  integrity sha512-Vwr7XSM10uZ1PauQDE3PEmK/Jg7k/2MRkmrCMAz8ou0YPQh2ZbPs17BBV227J/DWorSuSfHkoFIkPRfupaDDFA==
+  dependencies:
+    "@datadog/browser-core" "4.17.1"
+
+"@datadog/browser-rum-core@4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-rum-core/-/browser-rum-core-4.17.1.tgz#056cfe856126653d80535b5f592fb3dfc9dc88ad"
+  integrity sha512-DMUOJsotTwbsJT/wtGabTwC0laBB8RF55aCUk6Tqd4cZWJRnMIZHKgPB+KbTLunxg6Kw9PSGsvKXFPMcKy8UCg==
+  dependencies:
+    "@datadog/browser-core" "4.17.1"
+
+"@datadog/browser-rum@^4.17.1":
+  version "4.17.1"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-rum/-/browser-rum-4.17.1.tgz#a6b8a39c5ee9f16e00fb620fbecba8f402d7715c"
+  integrity sha512-dg9YkDKITUCzEYD7Avb8ranr1D9262WC2ryP3T435H38DoKVag+RvjBO5J1vY8R90OqxBRd2qQtFVNhRuDeKEg==
+  dependencies:
+    "@datadog/browser-core" "4.17.1"
+    "@datadog/browser-rum-core" "4.17.1"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"


### PR DESCRIPTION
##### Description

- add @datadog/browser-logs, @datadog/browser-rum
- add documentation on how monitoring should be used
- create default logging for routes
- init datadog

Additionally
- staging env on fleek has been populated with env variables meant for staging
- production env on fleek has been populated with env variables meant for production


##### Refers/Fixes

fixes https://github.com/gitcoinco/grants-round/issues/242

##### Testing

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/5358146/185106907-a1640d26-c673-47bf-b6b8-1d75088b4b8f.png">

![Deploy](https://user-images.githubusercontent.com/5358146/185107692-3ee71211-e020-45cd-b236-ecc30989199a.gif)
