### PR TITLE
feat: add error states to processing modal

### DIFF
--- a/packages/round-manager/src/constants.ts
+++ b/packages/round-manager/src/constants.ts
@@ -1,0 +1,1 @@
+export const errorModalDelayMs = 3000;

--- a/packages/round-manager/src/features/api/services/ipfs.ts
+++ b/packages/round-manager/src/features/api/services/ipfs.ts
@@ -10,6 +10,7 @@ export const ipfsApi = api.injectEndpoints({
         let result = { data: "" }
 
         try {
+          throw Error("ERROR....")
           const resp = await pinToIPFS(object)
 
           console.log('Added file to IPFS:', resp.IpfsHash)

--- a/packages/round-manager/src/features/api/services/ipfs.ts
+++ b/packages/round-manager/src/features/api/services/ipfs.ts
@@ -10,7 +10,6 @@ export const ipfsApi = api.injectEndpoints({
         let result = { data: "" }
 
         try {
-          throw Error("ERROR....")
           const resp = await pinToIPFS(object)
 
           console.log('Added file to IPFS:', resp.IpfsHash)

--- a/packages/round-manager/src/features/common/ErrorModal.tsx
+++ b/packages/round-manager/src/features/common/ErrorModal.tsx
@@ -7,6 +7,7 @@ interface ErrorModalProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   heading?: string;
   subheading?: string;
+  tryAgainFn?: () => void
 }
 
 export default function ErrorModal(
@@ -15,6 +16,7 @@ export default function ErrorModal(
     setIsOpen,
     heading = "Error",
     subheading = "There has been a systems error during the deployment of your Grant Program.",
+    tryAgainFn = () => {}
   }: ErrorModalProps
 ) {
 
@@ -57,6 +59,15 @@ export default function ErrorModal(
                     </div>
                   </div>
                   <div className="self-end mt-12">
+                    <Button
+                      type="button"
+                      $variant="outline"
+                      data-testid="tryAgain"
+                      onClick={() => {
+                        tryAgainFn()
+                        setIsOpen(false)
+                      }}
+                    >Try Again</Button>
                     <Button
                       type="button"
                       onClick={() => setIsOpen(false)}

--- a/packages/round-manager/src/features/common/ErrorModal.tsx
+++ b/packages/round-manager/src/features/common/ErrorModal.tsx
@@ -1,0 +1,74 @@
+import React, {Fragment} from "react"
+import {Dialog, Transition} from "@headlessui/react"
+import {Button} from "./styles";
+
+interface ErrorModalProps {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  heading?: string;
+  subheading?: string;
+}
+
+export default function ErrorModal(
+  {
+    isOpen,
+    setIsOpen,
+    heading = "Error",
+    subheading = "There has been a systems error during the deployment of your Grant Program.",
+  }: ErrorModalProps
+) {
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" data-testid="error-modal" className="relative z-10" onClose={() => setIsOpen(false)}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-grey-400 bg-opacity-75 transition-opacity" />
+        </Transition.Child>
+
+        <div className="fixed z-10 inset-0 overflow-y-auto">
+          <div className="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+              enterTo="opacity-100 translate-y-0 sm:scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+              leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            >
+              <Dialog.Panel className="relative bg-white px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
+                <div className="sm:flex sm:items-start flex-col">
+                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left ">
+                    <Dialog.Title as="h3" className="text-base leading-6 font-semibold text-grey-500" data-testid='error-heading'>
+                      {heading}
+                    </Dialog.Title>
+                    <div className="mt-2">
+                      <p className="text-sm text-grey-400" data-testid='error-message' >
+                        {subheading}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="self-end mt-12">
+                    <Button
+                      type="button"
+                      onClick={() => setIsOpen(false)}
+                      data-testid="done"
+                    >Done</Button>
+                  </div>
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  )
+}

--- a/packages/round-manager/src/features/common/ErrorModal.tsx
+++ b/packages/round-manager/src/features/common/ErrorModal.tsx
@@ -1,6 +1,7 @@
 import React, {Fragment} from "react"
 import {Dialog, Transition} from "@headlessui/react"
 import {Button} from "./styles";
+import { InformationCircleIcon } from "@heroicons/react/outline"
 
 interface ErrorModalProps {
   isOpen: boolean;
@@ -48,14 +49,19 @@ export default function ErrorModal(
             >
               <Dialog.Panel className="relative bg-white px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
                 <div className="sm:flex sm:items-start flex-col">
-                  <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left ">
-                    <Dialog.Title as="h3" className="text-base leading-6 font-semibold text-grey-500" data-testid='error-heading'>
-                      {heading}
-                    </Dialog.Title>
-                    <div className="mt-2">
-                      <p className="text-sm text-grey-400" data-testid='error-message' >
-                        {subheading}
-                      </p>
+                  <div className="flex flex-row justify-between">
+                    <div className="w-12 h-10 flex items-center justify-center bg-pink-100 rounded-full">
+                      <InformationCircleIcon className="w-5 h-5 text-pink-500"/>
+                    </div>
+                    <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+                      <Dialog.Title as="h3" className="text-base leading-6 font-semibold text-grey-500" data-testid='error-heading'>
+                        {heading}
+                      </Dialog.Title>
+                      <div className="mt-2">
+                        <p className="text-sm text-grey-400" data-testid='error-message' >
+                          {subheading}
+                        </p>
+                      </div>
                     </div>
                   </div>
                   <div className="self-end mt-12">
@@ -67,6 +73,7 @@ export default function ErrorModal(
                         tryAgainFn()
                         setIsOpen(false)
                       }}
+                      className="mr-4"
                     >Try Again</Button>
                     <Button
                       type="button"

--- a/packages/round-manager/src/features/common/ProgressModal.tsx
+++ b/packages/round-manager/src/features/common/ProgressModal.tsx
@@ -1,13 +1,14 @@
 import { Fragment, useEffect, useState } from "react"
 import { Dialog, Transition } from "@headlessui/react"
-import { CheckIcon } from "@heroicons/react/solid"
+import {CheckIcon, XIcon} from "@heroicons/react/solid"
+import { XCircleIcon } from "@heroicons/react/outline";
 
 interface ProgressModalProps {
   show: boolean;
   steps: Array<{
     name: string;
     description: string;
-    status: "complete" | "current" | "upcoming"
+    status: "complete" | "current" | "upcoming" | "error"
   }>;
   heading?: string;
   subheading?: string;
@@ -16,6 +17,32 @@ interface ProgressModalProps {
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(' ')
+}
+
+function ModalStep(props: {
+  step: { name: string; description: string; status: "complete" | "current" | "upcoming" | "error" },
+  icon: JSX.Element,
+  line: JSX.Element,
+  stepNameDarkGray?: boolean,
+  stepDescriptionDarkGray?: boolean,
+  isAriaHidden?: boolean,
+  isAriaCurrent?: boolean,
+  isLastStep?: boolean
+}) {
+  return <>
+    {!props.isLastStep ? (
+        props.line
+    ) : null}
+    <div className="relative flex items-start group" aria-current={!!props.isAriaCurrent}>
+      <span className="h-9 flex items-center" aria-hidden={!!props.isAriaHidden}>
+        {props.icon}
+      </span>
+      <span className="ml-4 min-w-0 flex flex-col">
+        <span className={`text-xs font-semibold tracking-wide uppercase ${props.stepNameDarkGray ? "text-grey-500" : "text-grey-400"}`}>{props.step.name}</span>
+        <span className={`text-sm ${props.stepDescriptionDarkGray ? "text-grey-500" : "text-grey-400"}`}>{props.step.description}</span>
+      </span>
+    </div>
+  </>;
 }
 
 export default function ProgressModal(
@@ -31,6 +58,7 @@ export default function ProgressModal(
   useEffect(() => {
     setOpen(props.show)
   }, [props.show])
+
 
   return (
     <Transition.Root show={open} as={Fragment}>
@@ -76,56 +104,53 @@ export default function ProgressModal(
                     {props.steps.map((step, stepIdx) => (
                       <li key={step.name} className={classNames(stepIdx !== props.steps.length - 1 ? 'pb-10' : '', 'relative')}>
                         {step.status === 'complete' ? (
-                          <>
-                            {stepIdx !== props.steps.length - 1 ? (
-                              <div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-teal-500" aria-hidden="true" />
-                            ) : null}
-                            <div className="relative flex items-start group">
-                              <span className="h-9 flex items-center">
+                            <ModalStep
+                              step={step}
+                              icon={
                                 <span className="relative z-10 w-8 h-8 flex items-center justify-center bg-teal-500 rounded-full">
                                   <CheckIcon className="w-5 h-5 text-white" aria-hidden="true" />
                                 </span>
-                              </span>
-                              <span className="ml-4 min-w-0 flex flex-col">
-                                <span className="text-xs font-semibold tracking-wide uppercase">{step.name}</span>
-                                <span className="text-sm text-grey-400">{step.description}</span>
-                              </span>
-                            </div>
-                          </>
+                              }
+                              line={<div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-teal-500" aria-hidden="true" />}
+                              stepNameDarkGray={true}
+                              stepDescriptionDarkGray={true}
+                              isLastStep={stepIdx === props.steps.length - 1}
+                            />
                         ) : step.status === 'current' ? (
-                          <>
-                            {stepIdx !== props.steps.length - 1 ? (
-                              <div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true" />
-                            ) : null}
-                            <div className="relative flex items-start group" aria-current="step">
-                              <span className="h-9 flex items-center" aria-hidden="true">
-                                <span className="relative z-10 w-8 h-8 flex items-center justify-center bg-white border-2 border-violet-500 rounded-full">
-                                  <span className="h-2.5 w-2.5 bg-violet-500 rounded-full" />
+                          <ModalStep
+                            step={step}
+                            icon={
+                              <span className="relative z-10 w-8 h-8 flex items-center justify-center bg-white border-2 border-violet-500 rounded-full">
+                                <span className="h-2.5 w-2.5 bg-violet-500 rounded-full" />
+                              </span>
+                            }
+                            line={<div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true" />}
+                            stepNameDarkGray={true}
+                            isLastStep={stepIdx === props.steps.length - 1}
+                          />
+                        ) : step.status === 'error' ? (
+                            <ModalStep
+                              step={step}
+                              icon={
+                                <span className="relative z-10 w-8 h-8 flex items-center justify-center border-2 bg-white border-pink-500 rounded-full">
+                                 <XIcon className="w-5 h-5 text-pink-500" data-testid="metadata-save-error-icon"/>
                                 </span>
-                              </span>
-                              <span className="ml-4 min-w-0 flex flex-col">
-                                <span className="text-xs font-semibold tracking-wide uppercase text-violet-500">{step.name}</span>
-                                <span className="text-sm text-grey-400">{step.description}</span>
-                              </span>
-                            </div>
-                          </>
+                              }
+                              line={<div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true"/>}
+                              isLastStep={stepIdx === props.steps.length - 1}
+                              stepNameDarkGray={true}
+                            />
                         ) : (
-                          <>
-                            {stepIdx !== props.steps.length - 1 ? (
-                              <div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true" />
-                            ) : null}
-                            <div className="relative flex items-start group">
-                              <span className="h-9 flex items-center" aria-hidden="true">
+                            <ModalStep
+                              step={step}
+                              icon={
                                 <span className="relative z-10 w-8 h-8 flex items-center justify-center bg-white border-2 border-gray-300 rounded-full group-hover:border-gray-400">
                                   <span className="h-2.5 w-2.5 bg-transparent rounded-full group-hover:bg-gray-300" />
                                 </span>
-                              </span>
-                              <span className="ml-4 min-w-0 flex flex-col">
-                                <span className="text-xs font-semibold tracking-wide uppercase text-grey-400">{step.name}</span>
-                                <span className="text-sm text-grey-400">{step.description}</span>
-                              </span>
-                            </div>
-                          </>
+                              }
+                              line={<div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true" />}
+                              isLastStep={stepIdx === props.steps.length - 1}
+                            />
                         )}
                       </li>
                     ))}

--- a/packages/round-manager/src/features/common/ProgressModal.tsx
+++ b/packages/round-manager/src/features/common/ProgressModal.tsx
@@ -4,7 +4,8 @@ import {CheckIcon, XIcon} from "@heroicons/react/solid"
 import { XCircleIcon } from "@heroicons/react/outline";
 
 interface ProgressModalProps {
-  show: boolean;
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   steps: Array<{
     name: string;
     description: string;
@@ -47,22 +48,18 @@ function ModalStep(props: {
 
 export default function ProgressModal(
   {
+    isOpen,
+    setIsOpen,
     heading = "Processing...",
     subheading = "Please hold while your operation is in progress.",
     redirectUrl = "",
     ...props
   }: ProgressModalProps
 ) {
-  const [open, setOpen] = useState(false)
-
-  useEffect(() => {
-    setOpen(props.show)
-  }, [props.show])
-
 
   return (
-    <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" data-testid="progress-modal" className="relative z-10" onClose={setIsOpen}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-300"

--- a/packages/round-manager/src/features/common/ProgressModal.tsx
+++ b/packages/round-manager/src/features/common/ProgressModal.tsx
@@ -1,7 +1,6 @@
-import { Fragment, useEffect, useState } from "react"
+import { Fragment } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import {CheckIcon, XIcon} from "@heroicons/react/solid"
-import { XCircleIcon } from "@heroicons/react/outline";
 
 interface ProgressModalProps {
   isOpen: boolean;
@@ -130,7 +129,7 @@ export default function ProgressModal(
                               step={step}
                               icon={
                                 <span className="relative z-10 w-8 h-8 flex items-center justify-center border-2 bg-white border-pink-500 rounded-full">
-                                 <XIcon className="w-5 h-5 text-pink-500" data-testid="metadata-save-error-icon"/>
+                                 <XIcon className="w-5 h-5 text-pink-500" data-testid={`${step.name}-error-icon`}/>
                                 </span>
                               }
                               line={<div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true"/>}

--- a/packages/round-manager/src/features/common/ProgressModal.tsx
+++ b/packages/round-manager/src/features/common/ProgressModal.tsx
@@ -45,6 +45,13 @@ function ModalStep(props: {
   </>;
 }
 
+export enum ProgressStatus {
+  COMPLETE = "complete",
+  CURRENT = "current",
+  UPCOMING = "upcoming",
+  ERROR = "error"
+}
+
 export default function ProgressModal(
   {
     isOpen,
@@ -99,7 +106,7 @@ export default function ProgressModal(
                   <ol className="overflow-hidden">
                     {props.steps.map((step, stepIdx) => (
                       <li key={step.name} className={classNames(stepIdx !== props.steps.length - 1 ? 'pb-10' : '', 'relative')}>
-                        {step.status === 'complete' ? (
+                        {step.status === ProgressStatus.COMPLETE ? (
                             <ModalStep
                               step={step}
                               icon={
@@ -112,7 +119,7 @@ export default function ProgressModal(
                               stepDescriptionDarkGray={true}
                               isLastStep={stepIdx === props.steps.length - 1}
                             />
-                        ) : step.status === 'current' ? (
+                        ) : step.status === ProgressStatus.CURRENT ? (
                           <ModalStep
                             step={step}
                             icon={
@@ -124,19 +131,19 @@ export default function ProgressModal(
                             stepNameDarkGray={true}
                             isLastStep={stepIdx === props.steps.length - 1}
                           />
-                        ) : step.status === 'error' ? (
+                        ) : step.status === ProgressStatus.ERROR ? (
                             <ModalStep
                               step={step}
                               icon={
                                 <span className="relative z-10 w-8 h-8 flex items-center justify-center border-2 bg-white border-pink-500 rounded-full">
-                                 <XIcon className="w-5 h-5 text-pink-500" data-testid={`${step.name}-error-icon`}/>
+                                 <XIcon className="w-5 h-5 text-pink-500" data-testid={`${step.name.toLowerCase()}-error-icon`}/>
                                 </span>
                               }
                               line={<div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true"/>}
                               isLastStep={stepIdx === props.steps.length - 1}
                               stepNameDarkGray={true}
                             />
-                        ) : (
+                        ) : step.status === ProgressStatus.UPCOMING ? (
                             <ModalStep
                               step={step}
                               icon={
@@ -147,7 +154,7 @@ export default function ProgressModal(
                               line={<div className="-ml-px absolute mt-0.5 top-4 left-4 w-0.5 h-full bg-gray-300" aria-hidden="true" />}
                               isLastStep={stepIdx === props.steps.length - 1}
                             />
-                        )}
+                        ) : <></> }
                       </li>
                     ))}
                   </ol>

--- a/packages/round-manager/src/features/common/__tests__/ProgressModal.test.tsx
+++ b/packages/round-manager/src/features/common/__tests__/ProgressModal.test.tsx
@@ -1,0 +1,50 @@
+import {screen} from "@testing-library/react"
+import {renderWrapped} from "../../../test-utils";
+import ProgressModal, {ProgressStatus} from "../ProgressModal";
+
+describe('<ProgressModal />',  () => {
+
+	it('shows error icon for the step when the step is in error', async () => {
+		const steps: Array<{
+			name: string;
+			description: string;
+			status: ProgressStatus
+		}> = [
+			{
+			name: "storing",
+			description: "",
+			status: ProgressStatus.ERROR
+		},
+		{
+			name: "deploying",
+			description: "",
+			status: ProgressStatus.UPCOMING
+		}];
+
+		renderWrapped(<ProgressModal isOpen={true} setIsOpen={() => {}} steps={steps} />);
+
+		await screen.findByTestId('storing-error-icon');
+	});
+
+	it('does not show error icon for a step that is not in error', async () => {
+		const steps: Array<{
+			name: string;
+			description: string;
+			status: ProgressStatus
+		}> = [
+			{
+				name: "storing",
+				description: "",
+				status: ProgressStatus.ERROR
+			},
+			{
+				name: "deploying",
+				description: "",
+				status: ProgressStatus.UPCOMING
+			}];
+
+		renderWrapped(<ProgressModal isOpen={true} setIsOpen={() => {}} steps={steps} />);
+
+		expect(screen.queryByTestId('deploying-error-icon')).not.toBeInTheDocument()
+	});
+});

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -103,7 +103,7 @@ export default function CreateProgram() {
     {
       name: "Storing",
       description: "The metadata is being saved in a safe place.",
-      status: isSavedToIPFS ? "complete" : (isSavingToIPFS ? "current" : "upcoming")
+      status: isSavedToIPFS ? "complete" : isIPFSError ? "error" : (isSavingToIPFS ? "current" : "upcoming")
     },
     {
       name: "Deploying",
@@ -160,6 +160,7 @@ export default function CreateProgram() {
                       disabled={isLoading}
                       placeholder="Enter the name of the Grant Program."
                       className="placeholder:italic"
+                      data-testid="program-name"
                     />
                     {errors.name && <p className="text-sm text-red-600">{errors.name?.message}</p>}
                   </div>
@@ -213,7 +214,7 @@ export default function CreateProgram() {
 
               <div className="px-6 align-middle pb-3.5 shadow-md">
                 <span className="italic text-grey-400">Note: You can't edit operator wallets after the grant is created.</span>
-                <Button className="float-right" type="submit" disabled={isLoading || isSavingToIPFS || isSuccess}>
+                <Button className="float-right" type="submit" disabled={isLoading || isSavingToIPFS || isSuccess} data-testid="save">
                   {isLoading || isSavingToIPFS ? "Saving..." : "Save"}
                 </Button>
               </div>

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -112,7 +112,7 @@ export default function CreateProgram() {
     {
       name: "Deploying",
       description: `Connecting to the ${chain.name} blockchain.`,
-      status: isSuccess ? "complete" : (isLoading ? "current" : "upcoming")
+      status: isSuccess ? "complete" : isProgramError ? "error" : (isLoading ? "current" : "upcoming")
     },
     {
       name: "Redirecting",

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -11,6 +11,7 @@ import Navbar from "../common/Navbar"
 import Footer from "../common/Footer"
 import ProgressModal from "../common/ProgressModal"
 import { datadogLogs } from "@datadog/browser-logs"
+import ErrorModal from "../common/ErrorModal"
 
 
 type FormData = {
@@ -23,17 +24,16 @@ export default function CreateProgram() {
   datadogLogs.logger.info(`====> URL: ${window.location.href}`)
 
   const [openProgressModal, setOpenProgressModal] = useState(false)
+  const [openErrorModal, setOpenErrorModal] = useState(false)
   const { address, chain, signer } = useWallet()
 
   const [saveToIPFS, {
-    // error: ipfsError,
     isError: isIPFSError,
     isLoading: isSavingToIPFS,
     isSuccess: isSavedToIPFS
   }] = useSaveToIPFSMutation()
 
   const [createProgram, {
-    // error: programError,
     isLoading,
     isSuccess,
     isError: isProgramError
@@ -67,6 +67,7 @@ export default function CreateProgram() {
   useEffect(() => {
     if (isIPFSError || isProgramError) {
       setOpenProgressModal(false)
+      setOpenErrorModal(true)
     }
   }, [isIPFSError, isProgramError])
 
@@ -221,10 +222,13 @@ export default function CreateProgram() {
             </form>
           </div>
           <ProgressModal
-            show={openProgressModal}
+            isOpen={openProgressModal}
+            setIsOpen={setOpenProgressModal}
             subheading={"Please hold while we create your Grant Program."}
             steps={progressSteps}
           />
+
+          <ErrorModal isOpen={openErrorModal} setIsOpen={setOpenErrorModal} />
         </main>
       </div>
       <Footer />

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -12,6 +12,7 @@ import Footer from "../common/Footer"
 import ProgressModal from "../common/ProgressModal"
 import { datadogLogs } from "@datadog/browser-logs"
 import ErrorModal from "../common/ErrorModal"
+import { errorModalDelayMs } from "../../constants"
 
 
 type FormData = {
@@ -66,8 +67,10 @@ export default function CreateProgram() {
 
   useEffect(() => {
     if (isIPFSError || isProgramError) {
-      setOpenProgressModal(false)
-      setOpenErrorModal(true)
+      setTimeout(() => {
+        setOpenProgressModal(false)
+        setOpenErrorModal(true)
+      }, errorModalDelayMs)
     }
   }, [isIPFSError, isProgramError])
 
@@ -228,7 +231,11 @@ export default function CreateProgram() {
             steps={progressSteps}
           />
 
-          <ErrorModal isOpen={openErrorModal} setIsOpen={setOpenErrorModal} />
+          <ErrorModal
+            isOpen={openErrorModal}
+            setIsOpen={setOpenErrorModal}
+            tryAgainFn={handleSubmit(onSubmit)}
+          />
         </main>
       </div>
       <Footer />

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -9,7 +9,7 @@ import { useSaveToIPFSMutation } from "../api/services/ipfs"
 import { Input, Button } from "../common/styles"
 import Navbar from "../common/Navbar"
 import Footer from "../common/Footer"
-import ProgressModal from "../common/ProgressModal"
+import ProgressModal, {ProgressStatus} from "../common/ProgressModal"
 import { datadogLogs } from "@datadog/browser-logs"
 import ErrorModal from "../common/ErrorModal"
 import { errorModalDelayMs } from "../../constants"
@@ -107,17 +107,17 @@ export default function CreateProgram() {
     {
       name: "Storing",
       description: "The metadata is being saved in a safe place.",
-      status: isSavedToIPFS ? "complete" : isIPFSError ? "error" : (isSavingToIPFS ? "current" : "upcoming")
+      status: isSavedToIPFS ? ProgressStatus.COMPLETE : isIPFSError ? ProgressStatus.ERROR : (isSavingToIPFS ? ProgressStatus.CURRENT : ProgressStatus.UPCOMING)
     },
     {
       name: "Deploying",
       description: `Connecting to the ${chain.name} blockchain.`,
-      status: isSuccess ? "complete" : isProgramError ? "error" : (isLoading ? "current" : "upcoming")
+      status: isSuccess ? ProgressStatus.COMPLETE : isProgramError ? ProgressStatus.ERROR : (isLoading ? ProgressStatus.CURRENT : ProgressStatus.UPCOMING)
     },
     {
       name: "Redirecting",
       description: "Just another moment while we finish things up.",
-      status: isSuccess ? "current" : "upcoming"
+      status: isSuccess ? ProgressStatus.CURRENT : ProgressStatus.UPCOMING
     }
   ]
 

--- a/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
+++ b/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
@@ -1,0 +1,44 @@
+import {fireEvent, screen} from "@testing-library/react"
+import {renderWrapped} from "../../../test-utils";
+import CreateProgramPage from "../CreateProgramPage";
+import { useWallet } from "../../common/Auth"
+
+import { useSaveToIPFSMutation } from "../../api/services/ipfs";
+import {useCreateProgramMutation} from "../../api/services/program";
+
+jest.mock("../../api/services/ipfs");
+jest.mock("../../api/services/program");
+jest.mock("../../common/Auth");
+jest.mock("@rainbow-me/rainbowkit", () => ({
+    ConnectButton: jest.fn(),
+}))
+
+describe('<CreateProgramPage />',  () => {
+    it('shows error icon when saving application meta data fails', async () => {
+        (useWallet as jest.Mock).mockReturnValue({ chain: {} });
+        let saveToIPFSStub = () => ({ unwrap: async () => Promise.resolve("asdfdsf") });
+        (useSaveToIPFSMutation as jest.Mock).mockReturnValue(
+    [
+            saveToIPFSStub, {
+            isError: true,
+            isLoading: false,
+            isSuccess: false
+        }]);
+        let createProgramStub = () => ({ unwrap: async () => Promise.resolve("asdfdsf") });
+        (useCreateProgramMutation as jest.Mock).mockReturnValue(
+            [
+                createProgramStub, {
+                isError: true,
+                isLoading: false,
+                isSuccess: false
+            }]);
+
+        renderWrapped(<CreateProgramPage />);
+        const save = screen.getByTestId('save');
+        const programName = screen.getByTestId('program-name');
+        fireEvent.change(programName, {target: {value: 'Program A'}})
+        fireEvent.click(save);
+
+        await screen.findByTestId('metadata-save-error-icon');
+    });
+});

--- a/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
+++ b/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
@@ -1,10 +1,11 @@
-import {fireEvent, screen} from "@testing-library/react"
+import { act, fireEvent, screen } from "@testing-library/react"
 import {renderWrapped} from "../../../test-utils";
 import CreateProgramPage from "../CreateProgramPage";
 import { useWallet } from "../../common/Auth"
 
 import { useSaveToIPFSMutation } from "../../api/services/ipfs";
 import {useCreateProgramMutation} from "../../api/services/program";
+import ErrorModal from "../../common/ErrorModal";
 
 jest.mock("../../api/services/ipfs");
 jest.mock("../../api/services/program");
@@ -14,31 +15,68 @@ jest.mock("@rainbow-me/rainbowkit", () => ({
 }))
 
 describe('<CreateProgramPage />',  () => {
-    it('shows error icon when saving application meta data fails', async () => {
-        (useWallet as jest.Mock).mockReturnValue({ chain: {} });
-        let saveToIPFSStub = () => ({ unwrap: async () => Promise.resolve("asdfdsf") });
-        (useSaveToIPFSMutation as jest.Mock).mockReturnValue(
-    [
-            saveToIPFSStub, {
-            isError: true,
-            isLoading: false,
-            isSuccess: false
-        }]);
-        let createProgramStub = () => ({ unwrap: async () => Promise.resolve("asdfdsf") });
-        (useCreateProgramMutation as jest.Mock).mockReturnValue(
-            [
-                createProgramStub, {
-                isError: true,
-                isLoading: false,
-                isSuccess: false
-            }]);
+  let saveToIPFSStub;
+  let createProgramStub;
 
-        renderWrapped(<CreateProgramPage />);
-        const save = screen.getByTestId('save');
-        const programName = screen.getByTestId('program-name');
+  beforeEach(() => {
+    (useWallet as jest.Mock).mockReturnValue({ chain: {} });
+    saveToIPFSStub = () => ({ unwrap: async () => Promise.resolve("asdfdsf") });
+    (useSaveToIPFSMutation as jest.Mock).mockReturnValue(
+      [
+        saveToIPFSStub, {
+        isError: true,
+        isLoading: false,
+        isSuccess: false
+      }]);
+
+    createProgramStub = () => ({ unwrap: async () => Promise.resolve("asdfdsf") });
+    (useCreateProgramMutation as jest.Mock).mockReturnValue(
+      [
+        createProgramStub, {
+        isError: true,
+        isLoading: false,
+        isSuccess: false
+      }]);
+  })
+
+  it('shows error icon when saving application meta data fails', async () => {
+      renderWrapped(<CreateProgramPage />);
+      const save = screen.getByTestId('save');
+      const programName = screen.getByTestId('program-name');
+      await act(() => {
         fireEvent.change(programName, {target: {value: 'Program A'}})
         fireEvent.click(save);
+      });
 
-        await screen.findByTestId('metadata-save-error-icon');
+      await screen.findByTestId('metadata-save-error-icon');
+  });
+
+  it("shows error modal when saving application meta data fails", async () => {
+    renderWrapped(<CreateProgramPage />);
+    const save = screen.getByTestId('save');
+    const programName = screen.getByTestId('program-name');
+    await act(() => {
+      fireEvent.change(programName, {target: {value: 'Program A'}})
+      fireEvent.click(save);
     });
-});
+
+    expect(await screen.findByTestId('error-modal')).toBeInTheDocument();
+  });
+
+  it('choosing done closes the error modal', async () => {
+    renderWrapped(<CreateProgramPage />);
+    const save = screen.getByTestId('save');
+    const programName = screen.getByTestId('program-name');
+    await act(() => {
+      fireEvent.change(programName, {target: {value: 'Program A'}})
+      fireEvent.click(save);
+    });
+
+    const done = await screen.findByTestId("done");
+    await act(() => {
+      fireEvent.click(done);
+    });
+
+    expect(screen.queryByTestId("error-modal")).not.toBeInTheDocument();
+  })
+})

--- a/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
+++ b/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
@@ -15,7 +15,7 @@ jest.mock("@rainbow-me/rainbowkit", () => ({
 
 jest.mock("../../../constants", () => ({
   ...jest.requireActual("../../../constants"),
-  errorModalDelayMs: 200 // NB: use smaller delay for faster tests
+  errorModalDelayMs: 0 // NB: use smaller delay for faster tests
 }))
 
 describe('<CreateProgramPage />',  () => {
@@ -82,6 +82,7 @@ describe('<CreateProgramPage />',  () => {
     });
 
     const saveToIpfsCalls = saveToIPFSStub.mock.calls.length;
+    expect(saveToIpfsCalls).toEqual(1);
 
     const tryAgain = await screen.findByTestId("tryAgain");
     await act(() => {

--- a/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
+++ b/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
@@ -20,7 +20,7 @@ jest.mock("../../../constants", () => ({
 
 describe('<CreateProgramPage />',  () => {
   let saveToIPFSStub: jest.MockedFn<any>;
-  let createProgramStub;
+  let createProgramStub: () => any;
 
   beforeEach(() => {
     (useWallet as jest.Mock).mockReturnValue({ chain: {} });
@@ -42,18 +42,6 @@ describe('<CreateProgramPage />',  () => {
         isSuccess: false
       }]);
   })
-
-  it('shows error icon when saving application meta data fails', async () => {
-      renderWrapped(<CreateProgramPage />);
-      const save = screen.getByTestId('save');
-      const programName = screen.getByTestId('program-name');
-      await act(() => {
-        fireEvent.change(programName, {target: {value: 'Program A'}})
-        fireEvent.click(save);
-      });
-
-      await screen.findByTestId('Storing-error-icon');
-  });
 
   it("shows error modal when saving application meta data fails", async () => {
     renderWrapped(<CreateProgramPage />);
@@ -122,17 +110,6 @@ describe('<CreateProgramPage />',  () => {
           isSuccess: false
         }]);
     })
-    it('shows error icon when create program transaction fails', async () => {
-      renderWrapped(<CreateProgramPage />);
-      const save = screen.getByTestId('save');
-      const programName = screen.getByTestId('program-name');
-      await act(() => {
-        fireEvent.change(programName, {target: {value: 'Program A'}})
-        fireEvent.click(save);
-      });
-
-      await screen.findByTestId('Deploying-error-icon');
-    });
 
     it("shows error modal when create program transaction fails", async () => {
       renderWrapped(<CreateProgramPage />);

--- a/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
+++ b/packages/round-manager/src/features/program/__tests__/CreateProgramPage.test.tsx
@@ -37,7 +37,7 @@ describe('<CreateProgramPage />',  () => {
     (useCreateProgramMutation as jest.Mock).mockReturnValue(
       [
         createProgramStub, {
-        isError: true,
+        isError: false,
         isLoading: false,
         isSuccess: false
       }]);
@@ -52,7 +52,7 @@ describe('<CreateProgramPage />',  () => {
         fireEvent.click(save);
       });
 
-      await screen.findByTestId('metadata-save-error-icon');
+      await screen.findByTestId('Storing-error-icon');
   });
 
   it("shows error modal when saving application meta data fails", async () => {
@@ -102,5 +102,48 @@ describe('<CreateProgramPage />',  () => {
 
     expect(screen.queryByTestId("error-modal")).not.toBeInTheDocument();
     expect(saveToIPFSStub.mock.calls.length).toEqual(saveToIpfsCalls + 1);
+  })
+
+  describe("when saving application metadata succeeds but create program transaction fails", () => {
+    beforeEach(() => {
+      (useSaveToIPFSMutation as jest.Mock).mockReturnValue(
+        [
+          saveToIPFSStub, {
+          isError: false,
+          isLoading: false,
+          isSuccess: true
+        }]);
+
+      (useCreateProgramMutation as jest.Mock).mockReturnValue(
+        [
+          createProgramStub, {
+          isError: true,
+          isLoading: false,
+          isSuccess: false
+        }]);
+    })
+    it('shows error icon when create program transaction fails', async () => {
+      renderWrapped(<CreateProgramPage />);
+      const save = screen.getByTestId('save');
+      const programName = screen.getByTestId('program-name');
+      await act(() => {
+        fireEvent.change(programName, {target: {value: 'Program A'}})
+        fireEvent.click(save);
+      });
+
+      await screen.findByTestId('Deploying-error-icon');
+    });
+
+    it("shows error modal when create program transaction fails", async () => {
+      renderWrapped(<CreateProgramPage />);
+      const save = screen.getByTestId('save');
+      const programName = screen.getByTestId('program-name');
+      await act(() => {
+        fireEvent.change(programName, {target: {value: 'Program A'}})
+        fireEvent.click(save);
+      });
+
+      expect(await screen.findByTestId('error-modal')).toBeInTheDocument();
+    });
   })
 })

--- a/packages/round-manager/src/features/program/__tests__/ErrorModal.test.tsx
+++ b/packages/round-manager/src/features/program/__tests__/ErrorModal.test.tsx
@@ -1,0 +1,24 @@
+import {screen} from "@testing-library/react"
+import {renderWrapped} from "../../../test-utils";
+import ErrorModal from "../../common/ErrorModal";
+
+jest.mock("../../api/services/ipfs");
+jest.mock("../../api/services/program");
+jest.mock("../../common/Auth");
+jest.mock("@rainbow-me/rainbowkit", () => ({
+	ConnectButton: jest.fn(),
+}))
+
+describe('<ErrorModal />',  () => {
+	it("shows error modal heading and error message", async () => {
+		renderWrapped(<ErrorModal heading="error title" subheading="this is an error message" isOpen={true} setIsOpen={() => {}}/>);
+		expect(await screen.findByTestId('error-heading')).toBeInTheDocument();
+		expect(await screen.findByTestId('error-message')).toBeInTheDocument();
+	});
+
+	it("does not show error modal heading when there is no error", async () => {
+		renderWrapped(<ErrorModal heading="error title" subheading="this is an error message" isOpen={false} setIsOpen={() => {}}/>);
+		expect(screen.queryByTestId('error-heading')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('error-message')).not.toBeInTheDocument();
+	});
+})

--- a/packages/round-manager/src/features/round/RoundApplicationForm.tsx
+++ b/packages/round-manager/src/features/round/RoundApplicationForm.tsx
@@ -434,7 +434,8 @@ export function RoundApplicationForm(props: { initialData: any, stepper: any }) 
             </div>
           </form>
           <ProgressModal
-            show={openProgressModal}
+            isOpen={openProgressModal}
+          setIsOpen={setOpenProgressModal}
             subheading={"Please hold while we create your Grant Round."}
             steps={progressSteps}
           />

--- a/packages/round-manager/src/features/round/RoundApplicationForm.tsx
+++ b/packages/round-manager/src/features/round/RoundApplicationForm.tsx
@@ -11,8 +11,10 @@ import { FormContext } from "../common/FormWizard"
 import { Button, Input } from "../common/styles"
 import { generateApplicationSchema } from "../api/utils"
 import { useWallet } from "../common/Auth"
-import ProgressModal from "../common/ProgressModal"
 import { PencilIcon, XIcon } from "@heroicons/react/solid"
+import ProgressModal, { ProgressStatus } from "../common/ProgressModal"
+import ErrorModal from "../common/ErrorModal"
+import { errorModalDelayMs } from "../../constants"
 
 
 const ValidationSchema = yup.object().shape({
@@ -35,6 +37,7 @@ export function RoundApplicationForm(props: { initialData: any, stepper: any }) 
   const [edit, setEdit] = useState(false)
   const { currentStep, setCurrentStep, stepsCount, formData } = useContext(FormContext)
   const FormStepper = props.stepper
+  const [openErrorModal, setOpenErrorModal] = useState(false)
 
   const search = useLocation().search
   const programId = (new URLSearchParams(search)).get("programId")
@@ -48,14 +51,12 @@ export function RoundApplicationForm(props: { initialData: any, stepper: any }) 
   const { chain, signer } = useWallet()
 
   const [saveToIPFS, {
-    // error: ipfsError,
     isLoading: isSavingToIPFS,
     isSuccess: isSavedToIPFS,
     isError: isIPFSError,
   }] = useSaveToIPFSMutation()
 
   const [createRound, {
-    // error: roundError,
     isLoading,
     isSuccess,
     isError: isRoundError,
@@ -75,7 +76,10 @@ export function RoundApplicationForm(props: { initialData: any, stepper: any }) 
 
   useEffect(() => {
     if (isIPFSError || isRoundError) {
-      setOpenProgressModal(false)
+      setTimeout(() =>{
+        setOpenProgressModal(false)
+        setOpenErrorModal(true)
+      }, errorModalDelayMs)
     }
   }, [isIPFSError, isRoundError])
 
@@ -140,17 +144,17 @@ export function RoundApplicationForm(props: { initialData: any, stepper: any }) 
     {
       name: "Storing",
       description: "The metadata is being saved in a safe place.",
-      status: isSavedToIPFS ? "complete" : (isSavingToIPFS ? "current" : "upcoming")
+      status: isSavedToIPFS ? ProgressStatus.COMPLETE : isIPFSError ? ProgressStatus.ERROR : (isSavingToIPFS ? ProgressStatus.CURRENT : ProgressStatus.UPCOMING)
     },
     {
       name: "Deploying",
       description: `Connecting to the ${chain.name} blockchain.`,
-      status: isSuccess ? "complete" : (isLoading ? "current" : "upcoming")
+      status: isSuccess ? ProgressStatus.COMPLETE : isRoundError ? ProgressStatus.ERROR : (isLoading ? ProgressStatus.CURRENT : ProgressStatus.UPCOMING)
     },
     {
       name: "Redirecting",
       description: "Just another moment while we finish things up.",
-      status: isSuccess ? "current" : "upcoming"
+      status: isSuccess ? ProgressStatus.CURRENT : ProgressStatus.UPCOMING
     }
   ]
 
@@ -438,6 +442,12 @@ export function RoundApplicationForm(props: { initialData: any, stepper: any }) 
           setIsOpen={setOpenProgressModal}
             subheading={"Please hold while we create your Grant Round."}
             steps={progressSteps}
+          />
+
+          <ErrorModal
+            isOpen={openErrorModal}
+            setIsOpen={setOpenErrorModal}
+            tryAgainFn={handleSubmit(next)}
           />
         </div>
       </div>

--- a/packages/round-manager/src/features/round/__tests__/RoundApplicationForm.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/RoundApplicationForm.test.tsx
@@ -1,0 +1,123 @@
+import { act, fireEvent, screen } from "@testing-library/react"
+import {renderWrapped} from "../../../test-utils";
+import {RoundApplicationForm} from "../RoundApplicationForm";
+import { useWallet } from "../../common/Auth"
+
+import { useSaveToIPFSMutation } from "../../api/services/ipfs";
+import {FormStepper} from "../../common/FormStepper";
+import {useCreateRoundMutation} from "../../api/services/round";
+
+jest.mock("../../api/services/ipfs");
+jest.mock("../../api/services/program");
+jest.mock("../../api/services/round");
+jest.mock("../../common/Auth");
+jest.mock("@rainbow-me/rainbowkit", () => ({
+	ConnectButton: jest.fn(),
+}))
+
+jest.mock("../../../constants", () => ({
+	...jest.requireActual("../../../constants"),
+	errorModalDelayMs: 0 // NB: use smaller delay for faster tests
+}))
+
+describe('<RoundApplicationForm />',  () => {
+	let saveToIPFSStub: jest.MockedFn<any>;
+	let createRoundStub: () => any;
+
+	beforeEach(() => {
+		(useWallet as jest.Mock).mockReturnValue({ chain: {} });
+		saveToIPFSStub = jest.fn().mockImplementation(() => ({ unwrap: async () => Promise.resolve("asdfdsf") }));
+		(useSaveToIPFSMutation as jest.Mock).mockReturnValue(
+			[
+				saveToIPFSStub, {
+				isError: true,
+				isLoading: false,
+				isSuccess: false
+			}]);
+
+		createRoundStub = () => ({ unwrap: async () => Promise.resolve("asdfdsf") });
+		(useCreateRoundMutation as jest.Mock).mockReturnValue(
+			[
+				createRoundStub, {
+				isError: false,
+				isLoading: false,
+				isSuccess: false
+			}]);
+	})
+
+	it("shows error modal when saving round application meta data fails", async () => {
+		renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+		const launch = screen.getByRole('button', {name: /Launch/i});
+		await act(() => {
+			fireEvent.click(launch)
+		})
+
+		expect(await screen.findByTestId('error-modal')).toBeInTheDocument();
+	});
+
+	it('choosing done closes the error modal', async () => {
+		renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+		const launch = screen.getByRole('button', {name: /Launch/i});
+		await act(() => {
+			fireEvent.click(launch)
+		})
+
+		const done = await screen.findByTestId("done");
+		await act(() => {
+			fireEvent.click(done);
+		});
+
+		expect(screen.queryByTestId("error-modal")).not.toBeInTheDocument();
+	})
+
+	it('choosing try again restarts the action and closes the error modal', async () => {
+		renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+
+		const launch = screen.getByRole('button', {name: /Launch/i});
+		await act(() => {
+			fireEvent.click(launch)
+		})
+
+		expect(screen.getByTestId("error-modal")).toBeInTheDocument();
+		const saveToIpfsCalls = saveToIPFSStub.mock.calls.length;
+		expect(saveToIpfsCalls).toEqual(2);
+
+		const tryAgain = await screen.findByTestId("tryAgain");
+		await act(() => {
+			fireEvent.click(tryAgain);
+		});
+
+		expect(screen.queryByTestId("error-modal")).not.toBeInTheDocument();
+		expect(saveToIPFSStub.mock.calls.length).toEqual(saveToIpfsCalls + 2);
+	})
+
+	describe("when saving round application metadata succeeds but create round transaction fails", () => {
+		beforeEach(() => {
+			(useSaveToIPFSMutation as jest.Mock).mockReturnValue(
+				[
+					saveToIPFSStub, {
+					isError: false,
+					isLoading: false,
+					isSuccess: true
+				}]);
+
+			(useCreateRoundMutation as jest.Mock).mockReturnValue(
+				[
+					createRoundStub, {
+					isError: true,
+					isLoading: false,
+					isSuccess: false
+				}]);
+		})
+
+		it("shows error modal when create round transaction fails", async () => {
+			renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+			const launch = screen.getByRole('button', {name: /Launch/i});
+			await act(() => {
+				fireEvent.click(launch)
+			})
+
+			expect(await screen.findByTestId('error-modal')).toBeInTheDocument();
+		});
+	})
+})


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

- show an error icon in the progress modal if a step fails
- replace progress modal with an error modal after ~3 seconds

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->
fixes #275

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
- ProgressModal.test.tsx
- CreateProgramPage.test.tsx
- RoundApplicationForm.test.tsx

Example screenshots:
![Screen Shot 2022-08-24 at 3 20 40 PM](https://user-images.githubusercontent.com/62616399/186515993-78ba7de9-496d-4417-8387-72fc3101fef6.png)
![Screen Shot 2022-08-24 at 3 20 43 PM](https://user-images.githubusercontent.com/62616399/186515999-1bf7fa24-1e11-419c-975b-be2069af6170.png)
![Screen Shot 2022-08-24 at 3 21 38 PM](https://user-images.githubusercontent.com/62616399/186516000-e2472405-9445-418f-a105-22590300e4e6.png)
![Screen Shot 2022-08-24 at 3 21 47 PM](https://user-images.githubusercontent.com/62616399/186516001-68c5c313-3de9-481b-8c1d-45aaa489267d.png)

