### PR TITLE
feat: add approve/reject buttons on approved applications

### DIFF
--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -14,7 +14,7 @@ import {
   Button
 } from "../common/styles"
 import { CheckIcon, XIcon } from "@heroicons/react/solid"
-import { GrantApplication } from "../api/types"
+import { GrantApplication, ProjectStatus } from "../api/types"
 import ConfirmationModal from "../common/ConfirmationModal"
 
 
@@ -57,22 +57,21 @@ export default function ApplicationsReceived({
     }
   }, [data, isSuccess, bulkSelect, signer])
 
-  const toggleSelection = (id: string, status: string) => {
-    const newState = selected?.map((obj: any) => {
-      const newStatus = obj.status === status ? "PENDING" : status
-
-      if (obj.id === id) {
-        return { ...obj, status: newStatus }
+  const toggleSelection = (id: string, status: ProjectStatus) => {
+    const newState = selected?.map((grantApp : GrantApplication) => {
+      if (grantApp.id === id) {
+        const newStatus = grantApp.status === status ? "PENDING" : status
+        return { ...grantApp, status: newStatus }
       }
 
-      return obj
+      return grantApp
     })
 
     setSelected(newState)
   }
 
   const checkSelection = (id: string) => {
-    return (selected?.find((obj: any) => obj.id === id))?.status
+    return (selected?.find((grantApp: GrantApplication) => grantApp.id === id))?.status
   }
 
   const handleBulkReview = async () => {

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -16,6 +16,11 @@ import tw from "tailwind-styled-components";
 import { Button } from "../common/styles"
 import { datadogLogs } from "@datadog/browser-logs"
 
+enum TabIndex {
+  PENDING = 0,
+  APPROVED = 1,
+  REJECTED = 2
+}
 
 export default function ViewRoundPage() {
 
@@ -52,6 +57,24 @@ export default function ViewRoundPage() {
   const pendingApplications = applications?.filter((a) => a.status === "PENDING") || []
   const approvedApplications = applications?.filter((a) => a.status === "APPROVED") || []
   const rejectedApplications = applications?.filter((a) => a.status === "REJECTED") || []
+
+  const [currentTabIndex, setCurrentTabIndex] = useState(TabIndex.PENDING);
+
+  const doesTabHaveApplications = (tabIndex: number): boolean => {
+    switch (tabIndex) {
+      case TabIndex.PENDING: {
+        return pendingApplications?.length > 0
+      }
+      case TabIndex.APPROVED: {
+        return approvedApplications?.length > 0
+      }
+      case TabIndex.REJECTED: {
+        return rejectedApplications?.length > 0
+      }
+      default:
+        return false
+    }
+  }
 
   const formatDate = (date: Date | undefined) => date?.toLocaleDateString()
 
@@ -119,7 +142,7 @@ export default function ViewRoundPage() {
             <div>
               <p className="text-bold text-md font-semibold mb-2">Grant Applications</p>
               <div>
-                <Tab.Group>
+                <Tab.Group onChange={setCurrentTabIndex}>
                   <Tab.List className="border-b mb-6 flex items-center justify-between">
                     <div className="space-x-8">
                       <Tab className={({ selected }) => tabStyles(selected)}>
@@ -156,7 +179,7 @@ export default function ViewRoundPage() {
                         }
                       </Tab>
                     </div>
-                    {pendingApplications?.length > 0 &&
+                    {doesTabHaveApplications(currentTabIndex) &&
                       <div className="justify-end">
                         <span className="text-grey-400 text-sm mr-6">
                           Save in gas fees by approving/rejecting multiple applications at once.
@@ -188,7 +211,7 @@ export default function ViewRoundPage() {
                       <ApplicationsReceived bulkSelect={bulkSelect} setBulkSelect={setBulkSelect} />
                     </Tab.Panel>
                     <Tab.Panel>
-                      <ApplicationsApproved />
+                      <ApplicationsApproved bulkSelect={bulkSelect} setBulkSelect={setBulkSelect}/>
                     </Tab.Panel>
                     <Tab.Panel>
                       <ApplicationsRejected />

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -1,0 +1,75 @@
+import ApplicationsApproved from "../ApplicationsApproved"
+import {
+  useBulkUpdateGrantApplicationsMutation,
+  useListGrantApplicationsQuery,
+} from "../../api/services/grantApplication"
+import { makeGrantApplicationData, renderWrapped } from "../../../test-utils"
+import { fireEvent, screen } from "@testing-library/react"
+
+jest.mock("../../api/services/grantApplication");
+jest.mock("../../common/Auth", () => ({
+  useWallet: () => ({ provider: {} })
+}))
+
+const grantApplications = [
+  makeGrantApplicationData({ status: "APPROVED" }),
+  makeGrantApplicationData({ status: "APPROVED" }),
+  makeGrantApplicationData({ status: "APPROVED" })
+];
+
+let bulkUpdateGrantApplications = jest.fn()
+
+describe("<ApplicationsApproved />", () => {
+  beforeEach(() => {
+    (useListGrantApplicationsQuery as any).mockReturnValue({
+      data: grantApplications, refetch: jest.fn(), isSuccess: true, isLoading: false
+    });
+
+    bulkUpdateGrantApplications = jest.fn().mockImplementation(
+      () => {
+        return {
+          unwrap: async () => Promise.resolve({
+            data: "hi ",
+          }),
+        }
+      },
+    );
+    (useBulkUpdateGrantApplicationsMutation as jest.Mock).mockReturnValue([
+      bulkUpdateGrantApplications,
+      {
+        isLoading: false
+      }
+    ]);
+  })
+
+  describe("when bulkSelect is true", () => {
+    it("renders approve and reject buttons on each project card", () => {
+
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />);
+      expect(screen.queryAllByTestId("bulk-approve-reject-buttons"))
+        .toHaveLength(grantApplications.length);
+    });
+
+    it("displays all approved buttons as selected when approved applications tab renders", () => {
+
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const approveButtons = screen.queryAllByTestId("approve-button")
+
+      approveButtons.forEach((button) => {
+        expect(button).toHaveClass("bg-teal-400 text-grey-500")
+      })
+      expect(approveButtons.length).toEqual(grantApplications.length)
+    });
+
+    it("displays a rejected button as selected when reject button is clicked", () => {
+
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const rejectButton = screen.queryAllByTestId("reject-button")[0]
+      fireEvent.click(rejectButton)
+
+      expect(rejectButton).toHaveClass("bg-white text-pink-500")
+    });
+  })
+})

--- a/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react"
+import { fireEvent, screen, waitFor } from "@testing-library/react"
 import { useWallet } from "../../common/Auth"
 import { useListRoundsQuery } from "../../api/services/round"
 import ViewRoundPage from "../ViewRoundPage"
@@ -161,4 +161,31 @@ describe('the view round page', () => {
       })).not.toBeInTheDocument()
     });
   });
+
+  describe("when there are approved applications and no pending applications", () => {
+    beforeEach(() => {
+      const mockApplicationData: GrantApplication[] = [
+        makeGrantApplicationData({ status: "APPROVED" }),
+        makeGrantApplicationData({ status: "APPROVED" }),
+        makeGrantApplicationData({ status: "REJECTED" }),
+      ];
+      (useListGrantApplicationsQuery as jest.Mock).mockReturnValue({
+        data: mockApplicationData,
+        isLoading: false,
+        isSuccess: true
+      })
+    })
+
+    it("should display the bulk select button when on the Approved tab", async () => {
+      renderWrapped(<ViewRoundPage />)
+      const approvedTab = screen.getByRole('tab', {
+        name: /Approved/i
+      });
+      fireEvent.click(approvedTab)
+
+      expect(screen.getByRole('button', {
+        name: /Select/i
+      })).toBeInTheDocument()
+    });
+  })
 })


### PR DESCRIPTION
- [ ] only allow operator to bulk-reject applications on approved tab
- [ ] add confirm step when bulk-selecting on approved tab

##### Description

- add bulk reject buttons and confirmation on applications in approved tab

##### Refers/Fixes

~~fix #299~~
fix #303

##### Testing

