### PR TITLE
bug: handle scenario where operator hasn't reviewed any projects in the round

### DIFF
--- a/packages/round-manager/src/features/api/services/grantApplication.ts
+++ b/packages/round-manager/src/features/api/services/grantApplication.ts
@@ -98,6 +98,9 @@ const updateApplicationStatusFromContract = async (
   applications: GrantApplication[], projectsMetaPtr: MetadataPointer, filterByStatus?: string
 ) => {
 
+  // Handle scenario where operator hasn't review any projects in the round
+  if (!projectsMetaPtr) return applications
+
   const applicationsFromContract = await fetchFromIPFS(projectsMetaPtr.pointer)
 
   // Iterate over all applications indexed by graph


### PR DESCRIPTION
##### Description

This covers a scenario where the project metaPtr hasn't been set yet.
Aka all projects are in pending state

##### Refers/Fixes

https://discord.com/channels/562828676480237578/1013943021387137035/1013943025275240490

##### Testing

locally tested