### PR TITLE
303  bulk reject approved applications

### DIFF
--- a/packages/round-manager/src/features/api/__tests__/program.test.ts
+++ b/packages/round-manager/src/features/api/__tests__/program.test.ts
@@ -3,7 +3,12 @@ import { Program } from "../types"
 import { makeProgramData } from "../../../test-utils"
 import { graphql_fetch, fetchFromIPFS } from "../utils"
 
-jest.mock("../utils")
+jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
+  graphql_fetch: jest.fn(),
+  fetchFromIPFS: jest.fn()
+}))
+
 
 describe("program api", () => {
   it("calls the graphql endpoint and maps the metadata from IPFS", async () => {

--- a/packages/round-manager/src/features/api/services/grantApplication.ts
+++ b/packages/round-manager/src/features/api/services/grantApplication.ts
@@ -88,6 +88,7 @@ const updateApplicationList = (applications: GrantApplication[], roundId: string
  *
  * @param applications
  * @param projectsMetaPtr
+ * @param filterByStatus
  *
  * @dev Once indexing IPFS content via graph is deterministic.
  *  - redeploy subgraph
@@ -99,7 +100,7 @@ const updateApplicationStatusFromContract = async (
 ) => {
 
   // Handle scenario where operator hasn't review any projects in the round
-  if (!projectsMetaPtr) return applications
+  if (!projectsMetaPtr) return filterByStatus ? applications.filter(application => application.status === filterByStatus) : applications
 
   const applicationsFromContract = await fetchFromIPFS(projectsMetaPtr.pointer)
 

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from "react-router-dom"
+import {Link, useParams} from "react-router-dom"
 
 import { useListGrantApplicationsQuery } from "../api/services/grantApplication"
 import { useWallet } from "../common/Auth"
@@ -15,6 +15,7 @@ import {
 import { XIcon } from "@heroicons/react/solid"
 import { GrantApplication, ProjectStatus } from "../api/types"
 import { useEffect, useState } from "react"
+import ConfirmationModal from "../common/ConfirmationModal";
 
 interface ApplicationsApprovedProps {
   bulkSelect?: boolean;
@@ -33,6 +34,7 @@ export default function ApplicationsApproved({
   })
 
   const [bulkSelectApproved, setBulkSelectApproved] = useState(bulkSelect)
+  const [openModal, setOpenModal] = useState(false)
   const [selected, setSelected] = useState<GrantApplication[]>([])
 
   useEffect(() => {
@@ -142,9 +144,31 @@ export default function ApplicationsApproved({
           <Spinner text="Fetching Grant Applications"/>
         }
       </CardsContainer>
-
-      <Continue grantApplications={selected} predicate={obj => obj.status === "REJECTED"} onClick={() => {
-      }}/>
+      {selected && selected?.filter(obj => obj.status === "REJECTED").length > 0  &&
+        <Continue grantApplications={selected} predicate={obj => obj.status === "REJECTED"}
+                  onClick={() => setOpenModal(true)}/>
+      }
+      <ConfirmationModal
+        title={"Confirm Decision"}
+        body={"You have selected multiple Grant Applications to be rejected."}
+        confirmButtonText={"Confirm"}
+        bodyStyled={
+          <>
+            <div className="flex my-8 gap-16 justify-center items-center text-center">
+              <div className="grid gap-2" data-testid="rejected-applications-count">
+                <i className="flex justify-center">
+                  <XIcon className="bg-pink-500 text-white rounded-full h-6 w-6 p-1" aria-hidden="true" />
+                </i>
+                <span className="text-xs text-grey-400 font-semibold text-center mt-2">REJECTED</span>
+                <span className="text-grey-500 font-semibold">{selected?.filter(obj => obj.status === "REJECTED").length}</span>
+              </div>
+            </div>
+            <p className="text-sm italic text-grey-400 mb-2">Changes could be subject to additional gas fees.</p>
+          </>
+        }
+        isOpen={openModal}
+        setIsOpen={setOpenModal}
+        confirmButtonAction={() => {}}/>
     </>
   )
   // TODO(shavinac) add confirm step

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -73,7 +73,7 @@ export default function ApplicationsApproved({
     try {
       await bulkUpdateGrantApplications({
         roundId: id!,
-        applications: selected.filter(application => application.status !== "PENDING"),
+        applications: selected.filter(application => application.status === "REJECTED"),
         signer,
         provider
       }).unwrap()

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -97,20 +97,20 @@ export default function ApplicationsApproved({
           <BasicCard key={index} className="application-card" data-testid="application-card">
           <CardHeader>
             {bulkSelectApproved && (
-                <div className="absolute flex gap-2 translate-x-[250px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
-                  <Button
-                    type="button"
-                    $variant="solid"
-                    className={
-                      `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "REJECTED"
-                        ? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
-                    }
-                    onClick={() => toggleRejection(application.id)}
-                    data-testid="reject-button"
-                  >
-                    <XIcon aria-hidden="true" />
-                  </Button>
-                </div>)}
+              <div className="absolute flex gap-2 translate-x-[250px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
+                <Button
+                  type="button"
+                  $variant="solid"
+                  className={
+                    `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "REJECTED"
+                      ? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
+                  }
+                  onClick={() => toggleRejection(application.id)}
+                  data-testid="reject-button"
+                >
+                  <XIcon aria-hidden="true" />
+                </Button>
+              </div>)}
               <div>
                 <img
                   className="h-[120px] w-full object-cover rounded-t"
@@ -135,14 +135,36 @@ export default function ApplicationsApproved({
                 <CardTitle>{application.project!.title}</CardTitle>
                 <CardDescription>{application.project!.description}</CardDescription>
               </CardContent>
-              </Link>
+            </Link>
           </BasicCard>
         ))}
         {isLoading &&
-          <Spinner text="Fetching Grant Applications" />
+          <Spinner text="Fetching Grant Applications"/>
         }
       </CardsContainer>
+
+      <Continue grantApplications={selected} predicate={obj => obj.status === "REJECTED"} onClick={() => {
+      }}/>
     </>
   )
   // TODO(shavinac) add confirm step
+}
+
+function Continue(props: { grantApplications: GrantApplication[], predicate: (obj: any) => boolean, onClick: () => void }) {
+  return <div className="fixed w-full left-0 bottom-0 bg-white">
+    <hr/>
+    <div className="flex justify-end items-center py-5 pr-20">
+      <span className="text-grey-400 text-sm mr-6">
+        You have selected {props.grantApplications?.filter(props.predicate).length} Grant Applications
+      </span>
+      <Button
+        type="button"
+        $variant="solid"
+        className="text-sm px-5"
+        onClick={props.onClick}
+      >
+        Continue
+      </Button>
+    </div>
+  </div>;
 }

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -12,7 +12,7 @@ import {
   CardDescription,
   Button,
 } from "../common/styles"
-import { CheckIcon, XIcon } from "@heroicons/react/solid"
+import { XIcon } from "@heroicons/react/solid"
 import { GrantApplication, ProjectStatus } from "../api/types"
 import { useEffect, useState } from "react"
 
@@ -24,7 +24,6 @@ interface ApplicationsApprovedProps {
 
 export default function ApplicationsApproved({
  bulkSelect = false,
- setBulkSelect = () => { },
 }: ApplicationsApprovedProps) {
   const { id } = useParams()
   const { provider, signer } = useWallet()
@@ -33,10 +32,11 @@ export default function ApplicationsApproved({
     roundId: id!, signerOrProvider: provider, status: "APPROVED"
   })
 
+  const [bulkSelectApproved, setBulkSelectApproved] = useState(bulkSelect)
   const [selected, setSelected] = useState<GrantApplication[]>([])
 
   useEffect(() => {
-    if (isSuccess || !bulkSelect) {
+    if (isSuccess || !bulkSelectApproved) {
       setSelected((data || []).map(application => {
         return {
           id: application.id,
@@ -47,7 +47,7 @@ export default function ApplicationsApproved({
         }
       }))
     }
-  }, [data, isSuccess, bulkSelect, signer])
+  }, [data, isSuccess, bulkSelectApproved, signer])
 
   const toggleRejection = (id: string) => {
     const newState = selected?.map((grantApp : GrantApplication) => {
@@ -67,24 +67,37 @@ export default function ApplicationsApproved({
   }
 
   return (
-    <CardsContainer>
-      {isSuccess && data?.map((application, index) => (
+    <>
+      <div className="justify-end">
+        <span className="text-grey-400 text-sm mr-6">
+          Save in gas fees by approving/rejecting multiple applications at once.
+        </span>
+        {bulkSelectApproved ?
+          <Button
+            type="button"
+            $variant="outline"
+            className="text-xs text-pink-500"
+            onClick={() => setBulkSelectApproved(false)}
+          >
+            Cancel
+          </Button>
+          :
+          <Button
+            type="button"
+            $variant="outline"
+            className="text-xs bg-grey-150 border-none"
+            onClick={() => setBulkSelectApproved(true)}
+          >
+            Select
+          </Button>
+        }
+      </div>
+      <CardsContainer>
+        {isSuccess && data?.map((application, index) => (
           <BasicCard key={index} className="application-card" data-testid="application-card">
           <CardHeader>
-            {bulkSelect && (
+            {bulkSelectApproved && (
                 <div className="absolute flex gap-2 translate-x-[250px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
-                  {/*<Button*/}
-                  {/*  type="button"*/}
-                  {/*  $variant="solid"*/}
-                  {/*  className={*/}
-                  {/*    `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "APPROVED"*/}
-                  {/*      ? "bg-teal-400 text-grey-500" : "bg-grey-500 text-white"}`*/}
-                  {/*  }*/}
-                  {/*  onClick={() => toggleSelection(application.id, "APPROVED")}*/}
-                  {/*  data-testid="approve-button"*/}
-                  {/*>*/}
-                  {/*  <CheckIcon aria-hidden="true" />*/}
-                  {/*</Button>*/}
                   <Button
                     type="button"
                     $variant="solid"
@@ -124,11 +137,12 @@ export default function ApplicationsApproved({
               </CardContent>
               </Link>
           </BasicCard>
-      ))}
-      {isLoading &&
-        <Spinner text="Fetching Grant Applications" />
-      }
-    </CardsContainer>
+        ))}
+        {isLoading &&
+          <Spinner text="Fetching Grant Applications" />
+        }
+      </CardsContainer>
+    </>
   )
   // TODO(shavinac) add confirm step
 }

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -9,53 +9,126 @@ import {
   CardHeader,
   CardContent,
   CardTitle,
-  CardDescription
+  CardDescription,
+  Button,
 } from "../common/styles"
+import { CheckIcon, XIcon } from "@heroicons/react/solid"
+import { GrantApplication, ProjectStatus } from "../api/types"
+import { useEffect, useState } from "react"
+
+interface ApplicationsApprovedProps {
+  bulkSelect?: boolean;
+  setBulkSelect?: (bulkSelect: boolean) => void;
+}
 
 
-export default function ApplicationsApproved() {
+export default function ApplicationsApproved({
+ bulkSelect = false,
+ setBulkSelect = () => { },
+}: ApplicationsApprovedProps) {
   const { id } = useParams()
-  const { provider } = useWallet()
+  const { provider, signer } = useWallet()
 
   const { data, isLoading, isSuccess } = useListGrantApplicationsQuery({
     roundId: id!, signerOrProvider: provider, status: "APPROVED"
   })
 
+  const [selected, setSelected] = useState<GrantApplication[]>([])
+
+  useEffect(() => {
+    if (isSuccess || !bulkSelect) {
+      setSelected((data || []).map(application => {
+        return {
+          id: application.id,
+          round: application.round,
+          recipient: application.recipient,
+          projectsMetaPtr: application.projectsMetaPtr,
+          status: application.status
+        }
+      }))
+    }
+  }, [data, isSuccess, bulkSelect, signer])
+
+  const toggleRejection = (id: string) => {
+    const newState = selected?.map((grantApp : GrantApplication) => {
+      if (grantApp.id === id) {
+        const newStatus: ProjectStatus = grantApp.status === "REJECTED" ? "APPROVED" : "REJECTED"
+        return { ...grantApp, status: newStatus }
+      }
+
+      return grantApp
+    })
+
+    setSelected(newState)
+  }
+
+  const checkSelection = (id: string) => {
+    return (selected?.find((grantApp: GrantApplication) => grantApp.id === id))?.status
+  }
+
   return (
     <CardsContainer>
       {isSuccess && data?.map((application, index) => (
-        <BasicCard key={index} className="application-card" data-testid="application-card">
+          <BasicCard key={index} className="application-card" data-testid="application-card">
           <CardHeader>
-            <div>
-              <img
-                className="h-[120px] w-full object-cover rounded-t"
-                src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.bannerImg}`}
-                alt=""
-              />
-            </div>
-            <div className="pl-4">
-              <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
-                <div className="flex">
-                  <img
-                    className="h-12 w-12 rounded-full ring-4 ring-white bg-white"
-                    src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.logoImg}`}
-                    alt=""
-                  />
+            {bulkSelect && (
+                <div className="absolute flex gap-2 translate-x-[250px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
+                  {/*<Button*/}
+                  {/*  type="button"*/}
+                  {/*  $variant="solid"*/}
+                  {/*  className={*/}
+                  {/*    `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "APPROVED"*/}
+                  {/*      ? "bg-teal-400 text-grey-500" : "bg-grey-500 text-white"}`*/}
+                  {/*  }*/}
+                  {/*  onClick={() => toggleSelection(application.id, "APPROVED")}*/}
+                  {/*  data-testid="approve-button"*/}
+                  {/*>*/}
+                  {/*  <CheckIcon aria-hidden="true" />*/}
+                  {/*</Button>*/}
+                  <Button
+                    type="button"
+                    $variant="solid"
+                    className={
+                      `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "REJECTED"
+                        ? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
+                    }
+                    onClick={() => toggleRejection(application.id)}
+                    data-testid="reject-button"
+                  >
+                    <XIcon aria-hidden="true" />
+                  </Button>
+                </div>)}
+              <div>
+                <img
+                  className="h-[120px] w-full object-cover rounded-t"
+                  src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.bannerImg}`}
+                  alt=""
+                />
+              </div>
+              <div className="pl-4">
+                <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
+                  <div className="flex">
+                    <img
+                      className="h-12 w-12 rounded-full ring-4 ring-white bg-white"
+                      src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.logoImg}`}
+                      alt=""
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-          </CardHeader>
-          <Link to={`/round/${id}/application/${application.id}`}>
-            <CardContent>
-              <CardTitle>{application.project!.title}</CardTitle>
-              <CardDescription>{application.project!.description}</CardDescription>
-            </CardContent>
-          </Link>
-        </BasicCard>
+            </CardHeader>
+            <Link to={`/round/${id}/application/${application.id}`}>
+              <CardContent>
+                <CardTitle>{application.project!.title}</CardTitle>
+                <CardDescription>{application.project!.description}</CardDescription>
+              </CardContent>
+              </Link>
+          </BasicCard>
       ))}
       {isLoading &&
         <Spinner text="Fetching Grant Applications" />
       }
     </CardsContainer>
   )
+  // TODO(shavinac) add confirm step
 }

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -86,7 +86,7 @@ export default function ApplicationsApproved({
 
   return (
     <>
-      <div className="justify-end">
+      {data && data.length > 0 && <div className="justify-end">
         <span className="text-grey-400 text-sm mr-6">
           Save in gas fees by approving/rejecting multiple applications at once.
         </span>
@@ -109,7 +109,7 @@ export default function ApplicationsApproved({
             Select
           </Button>
         }
-      </div>
+      </div>}
       <CardsContainer>
         {isSuccess && data?.map((application, index) => (
           <BasicCard key={index} className="application-card" data-testid="application-card">
@@ -188,7 +188,6 @@ export default function ApplicationsApproved({
       />
     </>
   )
-  // TODO(shavinac) add confirm step
 }
 
 function Continue(props: { grantApplications: GrantApplication[], predicate: (obj: any) => boolean, onClick: () => void }) {

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -18,17 +18,9 @@ import { GrantApplication, ProjectStatus } from "../api/types"
 import ConfirmationModal from "../common/ConfirmationModal"
 
 
-interface ApplicationsReceivedProps {
-  bulkSelect?: boolean;
-  setBulkSelect?: (bulkSelect: boolean) => void;
-}
-
-export default function ApplicationsReceived({
-  bulkSelect = false,
-  setBulkSelect = () => { },
-}: ApplicationsReceivedProps) {
+export default function ApplicationsReceived() {
   const [openModal, setOpenModal] = useState(false)
-
+  const [bulkSelect, setBulkSelect] = useState(false)
   const { id } = useParams()
   const { provider, signer } = useWallet()
 
@@ -91,6 +83,31 @@ export default function ApplicationsReceived({
 
   return (
     <div>
+      {data && data.length > 0 && <div className="justify-end">
+        <span className="text-grey-400 text-sm mr-6">
+          Save in gas fees by approving/rejecting multiple applications at once.
+        </span>
+        {bulkSelect ?
+          <Button
+            type="button"
+            $variant="outline"
+            className="text-xs text-pink-500"
+            onClick={() => setBulkSelect(false)}
+          >
+            Cancel
+          </Button>
+          :
+          <Button
+            type="button"
+            $variant="outline"
+            className="text-xs bg-grey-150 border-none"
+            onClick={() => setBulkSelect(true)}
+            data-testid="select"
+          >
+            Select
+          </Button>
+        }
+      </div>}
       <CardsContainer>
         {isSuccess && data?.map((application, index) => (
           <BasicCard key={index} className="application-card" data-testid="application-card">

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -23,7 +23,6 @@ interface ApplicationsReceivedProps {
   setBulkSelect?: (bulkSelect: boolean) => void;
 }
 
-
 export default function ApplicationsReceived({
   bulkSelect = false,
   setBulkSelect = () => { },

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -14,7 +14,7 @@ import {
   Button
 } from "../common/styles"
 import { CheckIcon, XIcon } from "@heroicons/react/solid"
-import { GrantApplication } from "../api/types"
+import { GrantApplication, ProjectStatus } from "../api/types"
 import ConfirmationModal from "../common/ConfirmationModal"
 
 
@@ -57,22 +57,21 @@ export default function ApplicationsReceived({
     }
   }, [data, isSuccess, bulkSelect, signer])
 
-  const toggleSelection = (id: string, status: string) => {
-    const newState = selected?.map((obj: any) => {
-      const newStatus = obj.status === status ? "PENDING" : status
-
-      if (obj.id === id) {
-        return { ...obj, status: newStatus }
+  const toggleSelection = (id: string, status: ProjectStatus) => {
+    const newState = selected?.map((grantApp : GrantApplication) => {
+      if (grantApp.id === id) {
+        const newStatus = grantApp.status === status ? "PENDING" : status
+        return { ...grantApp, status: newStatus }
       }
 
-      return obj
+      return grantApp
     })
 
     setSelected(newState)
   }
 
   const checkSelection = (id: string) => {
-    return (selected?.find((obj: any) => obj.id === id))?.status
+    return (selected?.find((grantApp: GrantApplication) => grantApp.id === id))?.status
   }
 
   const handleBulkReview = async () => {

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -17,18 +17,10 @@ import { datadogLogs } from "@datadog/browser-logs"
 import NotFoundPage from "../common/NotFoundPage"
 import AccessDenied from "../common/AccessDenied"
 
-enum TabIndex {
-  PENDING = 0,
-  APPROVED = 1,
-  REJECTED = 2
-}
-
 export default function ViewRoundPage() {
 
   datadogLogs.logger.info('====> Route: /round/create')
   datadogLogs.logger.info(`====> URL: ${window.location.href}`)
-
-  const [bulkSelectReceived, setBulkSelectReceived] = useState(false)
 
   const { id } = useParams()
   const { address, provider } = useWallet()
@@ -58,25 +50,6 @@ export default function ViewRoundPage() {
   const pendingApplications = applications?.filter((a) => a.status === "PENDING") || []
   const approvedApplications = applications?.filter((a) => a.status === "APPROVED") || []
   const rejectedApplications = applications?.filter((a) => a.status === "REJECTED") || []
-
-  const [currentTabIndex, setCurrentTabIndex] = useState(TabIndex.PENDING);
-
-  // TODO(shavinac) consider moving select/cancel button inside each tab component -- will discuss in standup
-  const doesTabHaveApplications = (tabIndex: number): boolean => {
-    switch (tabIndex) {
-      case TabIndex.PENDING: {
-        return pendingApplications?.length > 0
-      }
-      case TabIndex.APPROVED: {
-        return approvedApplications?.length > 0
-      }
-      case TabIndex.REJECTED: {
-        return rejectedApplications?.length > 0
-      }
-      default:
-        return false
-    }
-  }
 
   const formatDate = (date: Date | undefined) => date?.toLocaleDateString()
 
@@ -165,7 +138,7 @@ export default function ViewRoundPage() {
                 <div>
                   <p className="text-bold text-md font-semibold mb-2">Grant Applications</p>
                   <div>
-                    <Tab.Group onChange={setCurrentTabIndex}>
+                    <Tab.Group>
                       <Tab.List className="border-b mb-6 flex items-center justify-between">
                         <div className="space-x-8">
                           <Tab className={({ selected }) => tabStyles(selected)}>
@@ -205,7 +178,7 @@ export default function ViewRoundPage() {
                       </Tab.List>
                       <Tab.Panels>
                         <Tab.Panel>
-                          <ApplicationsReceived bulkSelect={bulkSelectReceived} setBulkSelect={setBulkSelectReceived} />
+                          <ApplicationsReceived />
                         </Tab.Panel>
                         <Tab.Panel>
                           <ApplicationsApproved />

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -30,7 +30,6 @@ export default function ViewRoundPage() {
 
   const [bulkSelectReceived, setBulkSelectReceived] = useState(false)
 
-
   const { id } = useParams()
   const { address, provider } = useWallet()
 

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -18,6 +18,11 @@ import { datadogLogs } from "@datadog/browser-logs"
 import NotFoundPage from "../common/NotFoundPage"
 import AccessDenied from "../common/AccessDenied"
 
+enum TabIndex {
+  PENDING = 0,
+  APPROVED = 1,
+  REJECTED = 2
+}
 
 export default function ViewRoundPage() {
 
@@ -54,6 +59,24 @@ export default function ViewRoundPage() {
   const pendingApplications = applications?.filter((a) => a.status === "PENDING") || []
   const approvedApplications = applications?.filter((a) => a.status === "APPROVED") || []
   const rejectedApplications = applications?.filter((a) => a.status === "REJECTED") || []
+
+  const [currentTabIndex, setCurrentTabIndex] = useState(TabIndex.PENDING);
+
+  const doesTabHaveApplications = (tabIndex: number): boolean => {
+    switch (tabIndex) {
+      case TabIndex.PENDING: {
+        return pendingApplications?.length > 0
+      }
+      case TabIndex.APPROVED: {
+        return approvedApplications?.length > 0
+      }
+      case TabIndex.REJECTED: {
+        return rejectedApplications?.length > 0
+      }
+      default:
+        return false
+    }
+  }
 
   const formatDate = (date: Date | undefined) => date?.toLocaleDateString()
 
@@ -142,7 +165,7 @@ export default function ViewRoundPage() {
                 <div>
                   <p className="text-bold text-md font-semibold mb-2">Grant Applications</p>
                   <div>
-                    <Tab.Group>
+                    <Tab.Group onChange={setCurrentTabIndex}>
                       <Tab.List className="border-b mb-6 flex items-center justify-between">
                         <div className="space-x-8">
                           <Tab className={({ selected }) => tabStyles(selected)}>
@@ -179,7 +202,7 @@ export default function ViewRoundPage() {
                             }
                           </Tab>
                         </div>
-                        {pendingApplications?.length > 0 &&
+                        {doesTabHaveApplications(currentTabIndex) &&
                           <div className="justify-end">
                             <span className="text-grey-400 text-sm mr-6">
                               Save in gas fees by approving/rejecting multiple applications at once.
@@ -211,7 +234,7 @@ export default function ViewRoundPage() {
                           <ApplicationsReceived bulkSelect={bulkSelect} setBulkSelect={setBulkSelect} />
                         </Tab.Panel>
                         <Tab.Panel>
-                          <ApplicationsApproved />
+                          <ApplicationsApproved bulkSelect={bulkSelect} setBulkSelect={setBulkSelect}/>
                         </Tab.Panel>
                         <Tab.Panel>
                           <ApplicationsRejected />

--- a/packages/round-manager/src/features/round/ViewRoundPage.tsx
+++ b/packages/round-manager/src/features/round/ViewRoundPage.tsx
@@ -13,7 +13,6 @@ import ApplicationsRejected from "./ApplicationsRejected"
 import Footer from "../common/Footer"
 import { useListGrantApplicationsQuery } from "../api/services/grantApplication";
 import tw from "tailwind-styled-components";
-import { Button } from "../common/styles"
 import { datadogLogs } from "@datadog/browser-logs"
 import NotFoundPage from "../common/NotFoundPage"
 import AccessDenied from "../common/AccessDenied"
@@ -29,7 +28,8 @@ export default function ViewRoundPage() {
   datadogLogs.logger.info('====> Route: /round/create')
   datadogLogs.logger.info(`====> URL: ${window.location.href}`)
 
-  const [bulkSelect, setBulkSelect] = useState(false)
+  const [bulkSelectReceived, setBulkSelectReceived] = useState(false)
+
 
   const { id } = useParams()
   const { address, provider } = useWallet()
@@ -62,6 +62,7 @@ export default function ViewRoundPage() {
 
   const [currentTabIndex, setCurrentTabIndex] = useState(TabIndex.PENDING);
 
+  // TODO(shavinac) consider moving select/cancel button inside each tab component -- will discuss in standup
   const doesTabHaveApplications = (tabIndex: number): boolean => {
     switch (tabIndex) {
       case TabIndex.PENDING: {
@@ -202,39 +203,13 @@ export default function ViewRoundPage() {
                             }
                           </Tab>
                         </div>
-                        {doesTabHaveApplications(currentTabIndex) &&
-                          <div className="justify-end">
-                            <span className="text-grey-400 text-sm mr-6">
-                              Save in gas fees by approving/rejecting multiple applications at once.
-                            </span>
-                            {bulkSelect ?
-                              <Button
-                                type="button"
-                                $variant="outline"
-                                className="text-xs text-pink-500"
-                                onClick={() => setBulkSelect(false)}
-                              >
-                                Cancel
-                              </Button>
-                              :
-                              <Button
-                                type="button"
-                                $variant="outline"
-                                className="text-xs bg-grey-150 border-none"
-                                onClick={() => setBulkSelect(true)}
-                              >
-                                Select
-                              </Button>
-                            }
-                          </div>
-                        }
                       </Tab.List>
                       <Tab.Panels>
                         <Tab.Panel>
-                          <ApplicationsReceived bulkSelect={bulkSelect} setBulkSelect={setBulkSelect} />
+                          <ApplicationsReceived bulkSelect={bulkSelectReceived} setBulkSelect={setBulkSelectReceived} />
                         </Tab.Panel>
                         <Tab.Panel>
-                          <ApplicationsApproved bulkSelect={bulkSelect} setBulkSelect={setBulkSelect}/>
+                          <ApplicationsApproved />
                         </Tab.Panel>
                         <Tab.Panel>
                           <ApplicationsRejected />
@@ -242,7 +217,6 @@ export default function ViewRoundPage() {
                       </Tab.Panels>
                     </Tab.Group>
                   </div>
-
                 </div>
               }
 

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -148,5 +148,30 @@ describe("<ApplicationsApproved />", () => {
       expect(continueButton).toBeInTheDocument();
       expect(screen.getByText(/You have selected 2 Grant Applications/i)).toBeInTheDocument();
     })
+
+    it("opens the confirmation modal when the continue button is clicked", async () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const rejectButton = screen.queryAllByTestId("reject-button")[0]
+      fireEvent.click(rejectButton)
+
+      const continueButton = screen.getByRole('button', {
+        name: /Continue/i
+      });
+      fireEvent.click(continueButton)
+
+      expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
+    })
+
+    it('does not show continue button when no applications are rejected', () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const continueButton = screen.queryByRole('button', {
+        name: /Continue/i
+      });
+
+      expect(continueButton).not.toBeInTheDocument();
+    })
+
   });
 })

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -4,7 +4,7 @@ import {
   useListGrantApplicationsQuery,
 } from "../../api/services/grantApplication"
 import {makeGrantApplicationData, renderWrapped} from "../../../test-utils"
-import {fireEvent, screen, waitForElementToBeRemoved} from "@testing-library/react"
+import {fireEvent, screen, waitForElementToBeRemoved, within} from "@testing-library/react";
 import {GrantApplication} from "../../api/types"
 
 jest.mock("../../api/services/grantApplication");
@@ -229,5 +229,27 @@ describe("<ApplicationsApproved />", () => {
       });
     })
 
+    it("closes the modal when cancel button is clicked on the modal", async () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true}/>)
+
+      const rejectButton = screen.queryAllByTestId("reject-button")[0]
+      fireEvent.click(rejectButton)
+
+      const continueButton = screen.getByRole('button', {
+        name: /Continue/i
+      });
+      fireEvent.click(continueButton)
+
+      const modal = screen.getByTestId("confirm-modal");
+
+      const modalCancelButton = within(modal).getByRole('button', {
+        name: /Cancel/i
+      });
+      fireEvent.click(modalCancelButton);
+
+      expect(bulkUpdateGrantApplications).not.toBeCalled();
+
+      expect(screen.queryByTestId("confirm-modal")).not.toBeInTheDocument();
+    });
   });
 })

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -98,6 +98,23 @@ describe("<ApplicationsApproved />", () => {
     });
   })
 
+  describe("when there are no approved applications", () => {
+    it("should not display the bulk select button", () => {
+      (useListGrantApplicationsQuery as any).mockReturnValue({
+        data: [], refetch: jest.fn(), isSuccess: true, isLoading: false
+      });
+
+      renderWrapped(<ApplicationsApproved />)
+
+      expect(screen.queryByText(
+        'Save in gas fees by approving/rejecting multiple applications at once.'
+      )).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', {
+        name: /Select/i
+      })).not.toBeInTheDocument()
+    })
+  })
+
   describe("when bulkSelect is true", () => {
     it("renders reject buttons on each project card", () => {
       renderWrapped(<ApplicationsApproved bulkSelect={true} />);

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -42,6 +42,52 @@ describe("<ApplicationsApproved />", () => {
     ]);
   })
 
+  describe('when approved applications are shown', () => {
+    it("should display the bulk select button", () => {
+      renderWrapped(<ApplicationsApproved />)
+      expect(screen.getByText(
+        'Save in gas fees by approving/rejecting multiple applications at once.'
+      )).toBeInTheDocument()
+      expect(screen.getByRole('button', {
+        name: /Select/i
+      })).toBeInTheDocument()
+    });
+
+    it("should display the cancel button when select is clicked", () => {
+      renderWrapped(<ApplicationsApproved />)
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
+      expect(screen.getByRole('button', {
+        name: /Cancel/i
+      })).toBeInTheDocument()
+      expect(screen.queryByRole('button', {
+        name: /Select/i
+      })).not.toBeInTheDocument()
+    });
+
+    it("should display the select button when cancel is clicked", () => {
+      renderWrapped(<ApplicationsApproved />)
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
+
+      const cancelButton = screen.getByRole('button', {
+        name: /Cancel/i
+      });
+      fireEvent.click(cancelButton)
+
+      expect(screen.queryByRole('button', {
+        name: /Cancel/i
+      })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', {
+        name: /Select/i
+      })).toBeInTheDocument()
+    });
+  })
+
   describe("when bulkSelect is true", () => {
     it("renders reject buttons on each project card", () => {
       renderWrapped(<ApplicationsApproved bulkSelect={true} />);

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -128,4 +128,25 @@ describe("<ApplicationsApproved />", () => {
       expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(0)
     })
   });
+
+  describe("when at least one application is selected", () => {
+    it("displays the continue button and copy", () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const rejectButton = screen.queryAllByTestId("reject-button")[0]
+      fireEvent.click(rejectButton)
+
+      const continueButton = screen.getByRole('button', {
+        name: /Continue/i
+      });
+      expect(continueButton).toBeInTheDocument();
+      expect(screen.getByText(/You have selected 1 Grant Applications/i)).toBeInTheDocument();
+
+      const rejectButton2 = screen.queryAllByTestId("reject-button")[1]
+      fireEvent.click(rejectButton2)
+
+      expect(continueButton).toBeInTheDocument();
+      expect(screen.getByText(/You have selected 2 Grant Applications/i)).toBeInTheDocument();
+    })
+  });
 })

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -1,0 +1,85 @@
+import ApplicationsApproved from "../ApplicationsApproved"
+import {
+  useBulkUpdateGrantApplicationsMutation,
+  useListGrantApplicationsQuery,
+} from "../../api/services/grantApplication"
+import { makeGrantApplicationData, renderWrapped } from "../../../test-utils"
+import { fireEvent, screen } from "@testing-library/react"
+
+jest.mock("../../api/services/grantApplication");
+jest.mock("../../common/Auth", () => ({
+  useWallet: () => ({ provider: {} })
+}))
+
+const grantApplications = [
+  makeGrantApplicationData({ status: "APPROVED" }),
+  makeGrantApplicationData({ status: "APPROVED" }),
+  makeGrantApplicationData({ status: "APPROVED" })
+];
+
+let bulkUpdateGrantApplications = jest.fn()
+
+describe("<ApplicationsApproved />", () => {
+  beforeEach(() => {
+    (useListGrantApplicationsQuery as any).mockReturnValue({
+      data: grantApplications, refetch: jest.fn(), isSuccess: true, isLoading: false
+    });
+
+    bulkUpdateGrantApplications = jest.fn().mockImplementation(
+      () => {
+        return {
+          unwrap: async () => Promise.resolve({
+            data: "hi ",
+          }),
+        }
+      },
+    );
+    (useBulkUpdateGrantApplicationsMutation as jest.Mock).mockReturnValue([
+      bulkUpdateGrantApplications,
+      {
+        isLoading: false
+      }
+    ]);
+  })
+
+  describe("when bulkSelect is true", () => {
+    it("renders reject buttons on each project card", () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />);
+      expect(screen.queryAllByTestId("reject-button"))
+        .toHaveLength(grantApplications.length);
+    });
+
+    it("does not display approve buttons in approved applications tab", () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const approveButtons = screen.queryAllByTestId("approve-button")
+      expect(approveButtons.length).toEqual(0)
+    });
+
+    it("selects a reject button when reject button is clicked", () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const rejectButton = screen.queryAllByTestId("reject-button")[0]
+      fireEvent.click(rejectButton)
+
+      expect(rejectButton).toHaveClass("bg-white text-pink-500")
+    });
+
+    it("unselects a reject button when a selected reject button is clicked", () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={true} />)
+
+      const rejectButton = screen.queryAllByTestId("reject-button")[0]
+      fireEvent.click(rejectButton)
+      fireEvent.click(rejectButton)
+
+      expect(rejectButton).not.toHaveClass("bg-white text-pink-500")
+    });
+  });
+
+  describe("when bulkSelect is false", () => {
+    it("does not render approve and reject buttons on each card", () => {
+      renderWrapped(<ApplicationsApproved bulkSelect={false} />)
+      expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(0)
+    })
+  });
+})

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
@@ -42,6 +42,69 @@ describe("<ApplicationsReceived />", () => {
     ]);
   })
 
+  describe("when there are no approved applications", () => {
+    it("should not display the bulk select button", () => {
+      (useListGrantApplicationsQuery as any).mockReturnValue({
+        data: [], refetch: jest.fn(), isSuccess: true, isLoading: false
+      });
+
+      renderWrapped(<ApplicationsReceived />)
+
+      expect(screen.queryByText(
+        'Save in gas fees by approving/rejecting multiple applications at once.'
+      )).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', {
+        name: /Select/i
+      })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('when received applications are shown', () => {
+    it("should display the bulk select button", () => {
+      renderWrapped(<ApplicationsReceived />)
+      expect(screen.getByText(
+        'Save in gas fees by approving/rejecting multiple applications at once.'
+      )).toBeInTheDocument()
+      expect(screen.getByRole('button', {
+        name: /Select/i
+      })).toBeInTheDocument()
+    });
+
+    it("should display the cancel button when select is clicked", () => {
+      renderWrapped(<ApplicationsReceived />)
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
+      expect(screen.getByRole('button', {
+        name: /Cancel/i
+      })).toBeInTheDocument()
+      expect(screen.queryByRole('button', {
+        name: /Select/i
+      })).not.toBeInTheDocument()
+    });
+
+    it("should display the select button when cancel is clicked", () => {
+      renderWrapped(<ApplicationsReceived />)
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
+
+      const cancelButton = screen.getByRole('button', {
+        name: /Cancel/i
+      });
+      fireEvent.click(cancelButton)
+
+      expect(screen.queryByRole('button', {
+        name: /Cancel/i
+      })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', {
+        name: /Select/i
+      })).toBeInTheDocument()
+    });
+  })
+
   it("renders no cards when there are no projects", () => {
     (useListGrantApplicationsQuery as any).mockReturnValue({
       data: [], isSuccess: true, isLoading: false
@@ -64,16 +127,19 @@ describe("<ApplicationsReceived />", () => {
   })
 
   describe("when bulkSelect is true", () => {
-    it("renders approve and reject buttons on each project card", () => {
 
-      renderWrapped(<ApplicationsReceived bulkSelect={true} />)
+    beforeEach(() => {
+      // eslint-disable-next-line testing-library/no-render-in-setup
+      renderWrapped(<ApplicationsReceived />)
+      const selectButton = screen.getByTestId('select')
+      fireEvent.click(selectButton);
+    })
+
+    it("renders approve and reject buttons on each project card", () => {
       expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(grantApplications.length)
     });
 
     it("displays an approved button as selected when approve button is clicked", () => {
-
-      renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
       const approveButton = screen.queryAllByTestId("approve-button")[0]
       fireEvent.click(approveButton)
 
@@ -81,9 +147,6 @@ describe("<ApplicationsReceived />", () => {
     });
 
     it("displays a rejected button as selected when reject button is clicked", () => {
-
-      renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
       const rejectButton = screen.queryAllByTestId("reject-button")[0]
       fireEvent.click(rejectButton)
 
@@ -92,8 +155,6 @@ describe("<ApplicationsReceived />", () => {
 
     describe("and when an approve button is already selected on a card", () => {
       it("selects the reject button and unselects the approve button when the reject button is clicked on that card", () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
 
@@ -104,8 +165,6 @@ describe("<ApplicationsReceived />", () => {
         expect(rejectButton).toHaveClass("bg-white text-pink-500")
       });
       it("unselects the approve button when that selected approve button is clicked on that card", () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         const approveButton = screen.queryAllByTestId("approve-button")[0]
 
         fireEvent.click(approveButton)
@@ -117,8 +176,6 @@ describe("<ApplicationsReceived />", () => {
 
     describe("and when an reject button is already selected on a card", () => {
       it("selects the approve button and unselects the reject button when the approve button is clicked on that card", () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
 
@@ -129,8 +186,6 @@ describe("<ApplicationsReceived />", () => {
         expect(rejectButton).not.toHaveClass("bg-white text-pink-500")
       });
       it("unselects the reject button when that selected reject button is clicked on that card", () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
 
         fireEvent.click(rejectButton)
@@ -141,8 +196,6 @@ describe("<ApplicationsReceived />", () => {
     });
 
     it("should approve individual applications independently", () => {
-      renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
       const firstApproveButton = screen.queryAllByTestId("approve-button")[0]
       fireEvent.click(firstApproveButton)
       expect(firstApproveButton).toHaveClass("bg-teal-400 text-grey-500")
@@ -154,8 +207,6 @@ describe("<ApplicationsReceived />", () => {
 
     describe("when at least one application is selected", () => {
       it("displays the continue button and copy", () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -173,8 +224,6 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("opens the confirmation modal when the continue button is clicked", async () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -187,8 +236,6 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("shows the correct number of approved and rejected applications in the confirmation modal", async () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         fireEvent.click(screen.queryAllByTestId("approve-button")[0])
         fireEvent.click(screen.queryAllByTestId("reject-button")[1])
         fireEvent.click(screen.queryAllByTestId("approve-button")[2])
@@ -206,8 +253,6 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("calls bulkUpdateGrantApplications when confirm button is clicked on the modal", async () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true} />)
-
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -227,8 +272,6 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("closes the modal when cancel button is clicked on the modal", async () => {
-        renderWrapped(<ApplicationsReceived bulkSelect={true}/>)
-
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -253,7 +296,7 @@ describe("<ApplicationsReceived />", () => {
 
   describe("when bulkSelect is false", () => {
     it("does not render approve and reject buttons on each card", () => {
-      renderWrapped(<ApplicationsReceived bulkSelect={false} />)
+      renderWrapped(<ApplicationsReceived />)
       expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(0)
     });
   });

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
@@ -225,6 +225,29 @@ describe("<ApplicationsReceived />", () => {
 
         await waitForElementToBeRemoved(() => screen.queryByTestId("confirm-modal"));
       })
+
+      it("closes the modal when cancel button is clicked on the modal", async () => {
+        renderWrapped(<ApplicationsReceived bulkSelect={true}/>)
+
+        const approveButton = screen.queryAllByTestId("approve-button")[0]
+        fireEvent.click(approveButton)
+
+        const continueButton = screen.getByRole('button', {
+          name: /Continue/i
+        });
+        fireEvent.click(continueButton)
+
+        const modal = screen.getByTestId("confirm-modal");
+
+        const modalCancelButton = within(modal).getByRole('button', {
+          name: /Cancel/i
+        });
+        fireEvent.click(modalCancelButton);
+
+        expect(bulkUpdateGrantApplications).not.toBeCalled();
+
+        expect(screen.queryByTestId("confirm-modal")).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/round-manager/src/features/round/__tests__/RoundApplicationForm.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/RoundApplicationForm.test.tsx
@@ -46,7 +46,9 @@ describe('<RoundApplicationForm />',  () => {
 	})
 
 	it("shows error modal when saving round application meta data fails", async () => {
-		renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+		renderWrapped(<RoundApplicationForm initialData={{ program: {
+		operatorWallets: []
+		}}} stepper={FormStepper} />);
 		const launch = screen.getByRole('button', {name: /Launch/i});
 		await act(() => {
 			fireEvent.click(launch)
@@ -56,7 +58,9 @@ describe('<RoundApplicationForm />',  () => {
 	});
 
 	it('choosing done closes the error modal', async () => {
-		renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+		renderWrapped(<RoundApplicationForm initialData={{ program: {
+				operatorWallets: []
+			}}} stepper={FormStepper} />);
 		const launch = screen.getByRole('button', {name: /Launch/i});
 		await act(() => {
 			fireEvent.click(launch)
@@ -71,7 +75,9 @@ describe('<RoundApplicationForm />',  () => {
 	})
 
 	it('choosing try again restarts the action and closes the error modal', async () => {
-		renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+		renderWrapped(<RoundApplicationForm initialData={{ program: {
+				operatorWallets: []
+			}}} stepper={FormStepper} />);
 
 		const launch = screen.getByRole('button', {name: /Launch/i});
 		await act(() => {
@@ -111,7 +117,9 @@ describe('<RoundApplicationForm />',  () => {
 		})
 
 		it("shows error modal when create round transaction fails", async () => {
-			renderWrapped(<RoundApplicationForm initialData={{}} stepper={FormStepper} />);
+			renderWrapped(<RoundApplicationForm initialData={{ program: {
+					operatorWallets: []
+				}}} stepper={FormStepper} />);
 			const launch = screen.getByRole('button', {name: /Launch/i});
 			await act(() => {
 				fireEvent.click(launch)

--- a/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react"
+import { fireEvent, screen, waitFor } from "@testing-library/react"
 import { useWallet } from "../../common/Auth"
 import { useListRoundsQuery } from "../../api/services/round"
 import ViewRoundPage from "../ViewRoundPage"
@@ -178,4 +178,31 @@ describe('the view round page', () => {
       })).not.toBeInTheDocument()
     });
   });
+
+  describe("when there are approved applications and no pending applications", () => {
+    beforeEach(() => {
+      const mockApplicationData: GrantApplication[] = [
+        makeGrantApplicationData({ status: "APPROVED" }),
+        makeGrantApplicationData({ status: "APPROVED" }),
+        makeGrantApplicationData({ status: "REJECTED" }),
+      ];
+      (useListGrantApplicationsQuery as jest.Mock).mockReturnValue({
+        data: mockApplicationData,
+        isLoading: false,
+        isSuccess: true
+      })
+    })
+
+    it("should display the bulk select button when on the Approved tab", async () => {
+      renderWrapped(<ViewRoundPage />)
+      const approvedTab = screen.getByRole('tab', {
+        name: /Approved/i
+      });
+      fireEvent.click(approvedTab)
+
+      expect(screen.getByRole('button', {
+        name: /Select/i
+      })).toBeInTheDocument()
+    });
+  })
 })

--- a/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -111,50 +111,6 @@ describe('the view round page', () => {
         isSuccess: true
       })
     })
-
-    it("should display the bulk select button", () => {
-      renderWrapped(<ViewRoundPage />)
-      expect(screen.getByText(
-        'Save in gas fees by approving/rejecting multiple applications at once.'
-      )).toBeInTheDocument()
-      expect(screen.getByRole('button', {
-        name: /Select/i
-      })).toBeInTheDocument()
-    });
-
-    it("should display the cancel button when select is clicked", () => {
-      renderWrapped(<ViewRoundPage />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
-      expect(screen.getByRole('button', {
-        name: /Cancel/i
-      })).toBeInTheDocument()
-      expect(screen.queryByRole('button', {
-        name: /Select/i
-      })).not.toBeInTheDocument()
-    });
-
-    it("should display the select button when cancel is clicked", () => {
-      renderWrapped(<ViewRoundPage />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
-
-      const cancelButton = screen.getByRole('button', {
-        name: /Cancel/i
-      });
-      fireEvent.click(cancelButton)
-
-      expect(screen.queryByRole('button', {
-        name: /Cancel/i
-      })).not.toBeInTheDocument()
-      expect(screen.getByRole('button', {
-        name: /Select/i
-      })).toBeInTheDocument()
-    });
   });
 
   describe("when there are no received applications", () => {

--- a/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -1,10 +1,13 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import { useWallet } from "../../common/Auth"
 import { useListRoundsQuery } from "../../api/services/round"
 import ViewRoundPage from "../ViewRoundPage"
 import { GrantApplication, Round } from "../../api/types"
-import { makeRoundData, renderWrapped, makeProgramData, makeGrantApplicationData } from "../../../test-utils"
-import { useBulkUpdateGrantApplicationsMutation, useListGrantApplicationsQuery } from "../../api/services/grantApplication"
+import { makeGrantApplicationData, makeProgramData, makeRoundData, renderWrapped } from "../../../test-utils"
+import {
+  useBulkUpdateGrantApplicationsMutation,
+  useListGrantApplicationsQuery,
+} from "../../api/services/grantApplication"
 import { useListProgramsQuery } from "../../api/services/program"
 import { useDisconnect, useSwitchNetwork } from "wagmi"
 
@@ -27,7 +30,7 @@ describe('the view round page', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (useWallet as jest.Mock).mockReturnValue({ chain: {}, address: mockRoundData.operatorWallets[0] });
+    (useWallet as jest.Mock).mockReturnValue({ chain: {}, address: mockRoundData.operatorWallets![0] });
 
     (useListRoundsQuery as jest.Mock).mockReturnValue({
       round: mockRoundData,
@@ -95,70 +98,5 @@ describe('the view round page', () => {
     expect(parseInt(screen.getByTestId('received-application-counter').textContent!!)).toBe(2)
     expect(parseInt(screen.getByTestId('rejected-application-counter').textContent!!)).toBe(1)
     expect(parseInt(screen.getByTestId('approved-application-counter').textContent!!)).toBe(1)
-  })
-
-  describe("when there are received applications", () => {
-    beforeEach(() => {
-      const mockApplicationData: GrantApplication[] = [
-        makeGrantApplicationData({ status: "PENDING" }),
-        makeGrantApplicationData({ status: "PENDING" }),
-        makeGrantApplicationData({ status: "REJECTED" }),
-        makeGrantApplicationData({ status: "APPROVED" }),
-      ];
-      (useListGrantApplicationsQuery as jest.Mock).mockReturnValue({
-        data: mockApplicationData,
-        isLoading: false,
-        isSuccess: true
-      })
-    })
-  });
-
-  describe("when there are no received applications", () => {
-    it("should not display the bulk select button", () => {
-      const mockApplicationData: GrantApplication[] = [
-        makeGrantApplicationData({ status: "REJECTED" }),
-        makeGrantApplicationData({ status: "APPROVED" }),
-      ];
-      (useListGrantApplicationsQuery as jest.Mock).mockReturnValue({
-        data: mockApplicationData,
-        isLoading: false,
-        isSuccess: true
-      })
-      renderWrapped(<ViewRoundPage />)
-
-      expect(screen.queryByText(
-        'Save in gas fees by approving/rejecting multiple applications at once.'
-      )).not.toBeInTheDocument()
-      expect(screen.queryByRole('button', {
-        name: /Select/i
-      })).not.toBeInTheDocument()
-    });
-  });
-
-  describe("when there are approved applications and no pending applications", () => {
-    beforeEach(() => {
-      const mockApplicationData: GrantApplication[] = [
-        makeGrantApplicationData({ status: "APPROVED" }),
-        makeGrantApplicationData({ status: "APPROVED" }),
-        makeGrantApplicationData({ status: "REJECTED" }),
-      ];
-      (useListGrantApplicationsQuery as jest.Mock).mockReturnValue({
-        data: mockApplicationData,
-        isLoading: false,
-        isSuccess: true
-      })
-    })
-
-    it("should display the bulk select button when on the Approved tab", async () => {
-      renderWrapped(<ViewRoundPage />)
-      const approvedTab = screen.getByRole('tab', {
-        name: /Approved/i
-      });
-      fireEvent.click(approvedTab)
-
-      expect(screen.getByRole('button', {
-        name: /Select/i
-      })).toBeInTheDocument()
-    });
   })
 })


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

- based on discussion with Eduardo, bulk select button is moved into individual tabs, instead of on top
- move bulk select button into received applications tab
- add bulk select button into approved applications tab

other:
- also fixes #316 bug where applications were incorrectly appearing in approved/rejected tabs
- updates RoundApplicationForm.test.tsx to silence `console.error` logs during test runs
- also fixes #319 error 3 - lit-sdk error during test run

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->
fixes #303

##### Testing
- ApplicationsApproved.test.tsx
- ApplicationsReceived.test.tsx
- ViewRoundPage.test.tsx
- RoundApplicationForm.test.tsx