### PR TITLE
refactor: added confirming text to approved tab

### DIFF
--- a/packages/round-manager/src/features/api/__tests__/program.test.ts
+++ b/packages/round-manager/src/features/api/__tests__/program.test.ts
@@ -9,6 +9,13 @@ jest.mock("../utils", () => ({
   fetchFromIPFS: jest.fn()
 }))
 
+jest.mock("../utils", () => ({
+  ...jest.requireActual("../utils"),
+  graphql_fetch: jest.fn(),
+  fetchFromIPFS: jest.fn()
+}))
+
+
 
 describe("program api", () => {
   it("calls the graphql endpoint and maps the metadata from IPFS", async () => {

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -1,42 +1,33 @@
 import {Link, useParams} from "react-router-dom"
 
 import {useBulkUpdateGrantApplicationsMutation, useListGrantApplicationsQuery} from "../api/services/grantApplication"
-import { useWallet } from "../common/Auth"
-import { Spinner } from "../common/Spinner"
-import {
-  CardsContainer,
-  BasicCard,
-  CardHeader,
-  CardContent,
-  CardTitle,
-  CardDescription,
-  Button,
-} from "../common/styles"
-import { XIcon } from "@heroicons/react/solid"
-import { GrantApplication, ProjectStatus } from "../api/types"
-import { useEffect, useState } from "react"
+import {useWallet} from "../common/Auth"
+import {Spinner} from "../common/Spinner"
+import {BasicCard, CardContent, CardDescription, CardHeader, CardsContainer, CardTitle,} from "../common/styles"
+import {GrantApplication, ProjectStatus} from "../api/types"
+import {useEffect, useState} from "react"
 import ConfirmationModal from "../common/ConfirmationModal";
+import {
+  AdditionalGasFeesNote,
+  ApplicationHeader,
+  Cancel,
+  Continue,
+  RejectedApplicationsCount,
+  Select
+} from "./BulkApplicationCommon";
 
-interface ApplicationsApprovedProps {
-  bulkSelect?: boolean;
-  setBulkSelect?: (bulkSelect: boolean) => void;
-}
 
-export default function ApplicationsApproved({
- bulkSelect = false,
-}: ApplicationsApprovedProps) {
+export default function ApplicationsApproved() {
   const { id } = useParams()
   const { provider, signer } = useWallet()
 
   const { data, isLoading, isSuccess } = useListGrantApplicationsQuery({
     roundId: id!, signerOrProvider: provider, status: "APPROVED"
   })
-
-  const [bulkSelectApproved, setBulkSelectApproved] = useState(bulkSelect)
+  const [bulkSelectApproved, setBulkSelectApproved] = useState(false)
   const [openModal, setOpenModal] = useState(false)
   const [selected, setSelected] = useState<GrantApplication[]>([])
-
-  const [bulkUpdateGrantApplications] = useBulkUpdateGrantApplicationsMutation()
+  const [bulkUpdateGrantApplications, { isLoading: isBulkUpdateLoading } ] = useBulkUpdateGrantApplicationsMutation()
 
   useEffect(() => {
     if (isSuccess || !bulkSelectApproved) {
@@ -65,7 +56,7 @@ export default function ApplicationsApproved({
     setSelected(newState)
   }
 
-  const checkSelection = (id: string) => {
+  const checkSelectionStatus = (id: string) => {
     return (selected?.find((grantApp: GrantApplication) => grantApp.id === id))?.status
   }
 
@@ -91,62 +82,20 @@ export default function ApplicationsApproved({
           Save in gas fees by approving/rejecting multiple applications at once.
         </span>
         {bulkSelectApproved ?
-          <Button
-            type="button"
-            $variant="outline"
-            className="text-xs text-pink-500"
-            onClick={() => setBulkSelectApproved(false)}
-          >
-            Cancel
-          </Button>
-          :
-          <Button
-            type="button"
-            $variant="outline"
-            className="text-xs bg-grey-150 border-none"
-            onClick={() => setBulkSelectApproved(true)}
-          >
-            Select
-          </Button>
+          <Cancel onClick={() => setBulkSelectApproved(false)}/> :
+          <Select onClick={() => setBulkSelectApproved(true)}/>
         }
       </div>}
       <CardsContainer>
         {isSuccess && data?.map((application, index) => (
           <BasicCard key={index} className="application-card" data-testid="application-card">
           <CardHeader>
-            {bulkSelectApproved && (
-              <div className="absolute flex gap-2 translate-x-[250px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
-                <Button
-                  type="button"
-                  $variant="solid"
-                  className={
-                    `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "REJECTED"
-                      ? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
-                  }
-                  onClick={() => toggleRejection(application.id)}
-                  data-testid="reject-button"
-                >
-                  <XIcon aria-hidden="true" />
-                </Button>
-              </div>)}
-              <div>
-                <img
-                  className="h-[120px] w-full object-cover rounded-t"
-                  src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.bannerImg}`}
-                  alt=""
-                />
-              </div>
-              <div className="pl-4">
-                <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
-                  <div className="flex">
-                    <img
-                      className="h-12 w-12 rounded-full ring-4 ring-white bg-white"
-                      src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.logoImg}`}
-                      alt=""
-                    />
-                  </div>
-                </div>
-              </div>
+            <ApplicationHeader
+              bulkSelect={bulkSelectApproved}
+              applicationStatus={checkSelectionStatus(application.id)}
+              rejectOnClick={() => toggleRejection(application.id)}
+            application={application}
+            />
             </CardHeader>
             <Link to={`/round/${id}/application/${application.id}`}>
               <CardContent>
@@ -161,12 +110,11 @@ export default function ApplicationsApproved({
         }
       </CardsContainer>
       {selected && selected?.filter(obj => obj.status === "REJECTED").length > 0  &&
-        <Continue grantApplications={selected} predicate={obj => obj.status === "REJECTED"}
-                  onClick={() => setOpenModal(true)}/>
+        <Continue grantApplications={selected} status="REJECTED" onClick={() => setOpenModal(true)}/>
       }
       <ConfirmationModal
         title={"Confirm Decision"}
-        confirmButtonText={"Confirm"}
+        confirmButtonText={isBulkUpdateLoading ? "Confirming..." : "Confirm"}
         confirmButtonAction={handleBulkReview}
         body={
           <>
@@ -174,15 +122,9 @@ export default function ApplicationsApproved({
               {"You have selected multiple Grant Applications to be rejected."}
             </p>
             <div className="flex my-8 gap-16 justify-center items-center text-center">
-              <div className="grid gap-2" data-testid="rejected-applications-count">
-                <i className="flex justify-center">
-                  <XIcon className="bg-pink-500 text-white rounded-full h-6 w-6 p-1" aria-hidden="true" />
-                </i>
-                <span className="text-xs text-grey-400 font-semibold text-center mt-2">REJECTED</span>
-                <span className="text-grey-500 font-semibold">{selected?.filter(obj => obj.status === "REJECTED").length}</span>
-              </div>
+              <RejectedApplicationsCount grantApplications={selected}/>
             </div>
-            <p className="text-sm italic text-grey-400 mb-2">Changes could be subject to additional gas fees.</p>
+            <AdditionalGasFeesNote />
           </>
         }
         isOpen={openModal}
@@ -190,23 +132,4 @@ export default function ApplicationsApproved({
       />
     </>
   )
-}
-
-function Continue(props: { grantApplications: GrantApplication[], predicate: (obj: any) => boolean, onClick: () => void }) {
-  return <div className="fixed w-full left-0 bottom-0 bg-white">
-    <hr/>
-    <div className="flex justify-end items-center py-5 pr-20">
-      <span className="text-grey-400 text-sm mr-6">
-        You have selected {props.grantApplications?.filter(props.predicate).length} Grant Applications
-      </span>
-      <Button
-        type="button"
-        $variant="solid"
-        className="text-sm px-5"
-        onClick={props.onClick}
-      >
-        Continue
-      </Button>
-    </div>
-  </div>;
 }

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -45,7 +45,7 @@ export default function ApplicationsReceived() {
         }
       }))
     }
-  }, [data, isSuccess, bulkSelect, signer])
+  }, [data, isSuccess, bulkSelect])
 
   const toggleSelection = (id: string, status: ProjectStatus) => {
     const newState = selected?.map((grantApp : GrantApplication) => {

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -1,21 +1,20 @@
-import { useEffect, useState } from "react"
-import { Link, useParams } from "react-router-dom"
-import { InboxInIcon as NoApplicationsForRoundIcon } from "@heroicons/react/outline"
-import { useBulkUpdateGrantApplicationsMutation, useListGrantApplicationsQuery } from "../api/services/grantApplication"
-import { useWallet } from "../common/Auth"
-import { Spinner } from "../common/Spinner"
-import {
-  CardsContainer,
-  BasicCard,
-  CardHeader,
-  CardContent,
-  CardTitle,
-  CardDescription,
-  Button
-} from "../common/styles"
-import { CheckIcon, XIcon } from "@heroicons/react/solid"
-import { GrantApplication, ProjectStatus } from "../api/types"
+import {useEffect, useState} from "react"
+import {Link, useParams} from "react-router-dom"
+import {InboxInIcon as NoApplicationsForRoundIcon} from "@heroicons/react/outline"
+import {useBulkUpdateGrantApplicationsMutation, useListGrantApplicationsQuery} from "../api/services/grantApplication"
+import {useWallet} from "../common/Auth"
+import {Spinner} from "../common/Spinner"
+import {BasicCard, Button, CardContent, CardDescription, CardHeader, CardsContainer, CardTitle} from "../common/styles"
+import {GrantApplication, ProjectStatus} from "../api/types"
 import ConfirmationModal from "../common/ConfirmationModal"
+import {
+  AdditionalGasFeesNote,
+  ApplicationHeader,
+  ApprovedApplicationsCount,
+  Cancel,
+  RejectedApplicationsCount,
+  Select
+} from "./BulkApplicationCommon";
 
 
 export default function ApplicationsReceived() {
@@ -46,7 +45,7 @@ export default function ApplicationsReceived() {
         }
       }))
     }
-  }, [data, isSuccess, bulkSelect])
+  }, [data, isSuccess, bulkSelect, signer])
 
   const toggleSelection = (id: string, status: ProjectStatus) => {
     const newState = selected?.map((grantApp : GrantApplication) => {
@@ -61,7 +60,7 @@ export default function ApplicationsReceived() {
     setSelected(newState)
   }
 
-  const checkSelection = (id: string) => {
+  const checkSelectionStatus = (id: string) => {
     return (selected?.find((grantApp: GrantApplication) => grantApp.id === id))?.status
   }
 
@@ -88,77 +87,20 @@ export default function ApplicationsReceived() {
           Save in gas fees by approving/rejecting multiple applications at once.
         </span>
         {bulkSelect ?
-          <Button
-            type="button"
-            $variant="outline"
-            className="text-xs text-pink-500"
-            onClick={() => setBulkSelect(false)}
-          >
-            Cancel
-          </Button>
-          :
-          <Button
-            type="button"
-            $variant="outline"
-            className="text-xs bg-grey-150 border-none"
-            onClick={() => setBulkSelect(true)}
-            data-testid="select"
-          >
-            Select
-          </Button>
+          <Cancel onClick={() => setBulkSelect(false)}/> :
+          <Select onClick={() => setBulkSelect(true)}/>
         }
       </div>}
       <CardsContainer>
         {isSuccess && data?.map((application, index) => (
           <BasicCard key={index} className="application-card" data-testid="application-card">
             <CardHeader>
-              {bulkSelect && (
-                <div className="absolute flex gap-2 translate-x-[206px] translate-y-4 mr-4" data-testid="bulk-approve-reject-buttons">
-                  <Button
-                    type="button"
-                    $variant="solid"
-                    className={
-                      `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "APPROVED"
-                        ? "bg-teal-400 text-grey-500" : "bg-grey-500 text-white"}`
-                    }
-                    onClick={() => toggleSelection(application.id, "APPROVED")}
-                    data-testid="approve-button"
-                  >
-                    <CheckIcon aria-hidden="true" />
-                  </Button>
-                  <Button
-                    type="button"
-                    $variant="solid"
-                    className={
-                      `border border-grey-400 w-9 h-8 p-2.5 ${checkSelection(application.id) === "REJECTED"
-                        ? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
-                    }
-                    onClick={() => toggleSelection(application.id, "REJECTED")}
-                    data-testid="reject-button"
-                  >
-                    <XIcon aria-hidden="true" />
-                  </Button>
-                </div>)}
-              <div>
-                <div>
-                  <img
-                    className="h-[120px] w-full object-cover rounded-t"
-                    src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.bannerImg}`}
-                    alt=""
-                  />
-                </div>
-                <div className="pl-4">
-                  <div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
-                    <div className="flex">
-                      <img
-                        className="h-12 w-12 rounded-full ring-4 ring-white bg-white"
-                        src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${application.project!.logoImg}`}
-                        alt=""
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
+              <ApplicationHeader
+                bulkSelect={bulkSelect}
+                applicationStatus={checkSelectionStatus(application.id)}
+                approveOnClick={() => toggleSelection(application.id, "APPROVED")}
+                rejectOnClick={() => toggleSelection(application.id, "REJECTED")}
+                application={application}/>
             </CardHeader>
             <Link to={`/round/${id}/application/${application.id}`}>
               <CardContent>
@@ -173,12 +115,11 @@ export default function ApplicationsReceived() {
         }
         {!isLoading && data?.length === 0 &&
           <div className="flex flex-center flex-col mx-auto h-screen items-center text-center mt-32">
-            <div className="flex flex-center justify-center items-center bg-grey-150 rounded-full h-12 w-12 text-violet-400">
-              <NoApplicationsForRoundIcon className="w-6 h-6" />
+            <div
+              className="flex flex-center justify-center items-center bg-grey-150 rounded-full h-12 w-12 text-violet-400">
+              <NoApplicationsForRoundIcon className="w-6 h-6"/>
             </div>
-            <h2 className="mt-8 text-2xl antialiased">No Applications</h2>
-            <div className="mt-2 text-sm">Applications have not been submitted yet.</div>
-            <div className="text-sm">Try promoting your Grant Program to get more traction!</div>
+            <NoApplicationsMessage/>
           </div>
 
         }
@@ -186,19 +127,11 @@ export default function ApplicationsReceived() {
       {selected && selected?.filter(obj => obj.status !== "PENDING").length > 0 && (
         <>
           <div className="fixed w-full left-0 bottom-0 bg-white">
-            <hr />
+            <hr/>
             <div className="flex justify-end items-center py-5 pr-20">
-              <span className="text-grey-400 text-sm mr-6">
-                You have selected {selected?.filter(obj => obj.status !== "PENDING").length} Grant Applications
-              </span>
-              <Button
-                type="button"
-                $variant="solid"
-                className="text-sm px-5"
-                onClick={() => setOpenModal(true)}
-              >
-                Continue
-              </Button>
+              <NumberOfApplicationsSelectedMessage grantApplications={selected}
+                                                   predicate={selected => selected.status !== "PENDING"}/>
+              <Continue onClick={() => setOpenModal(true)}/>
             </div>
           </div>
           <ConfirmationModal
@@ -210,23 +143,11 @@ export default function ApplicationsReceived() {
                   {"You have selected multiple Grant Applications to approve and/or reject."}
                 </p>
                 <div className="flex my-8 gap-16 justify-center items-center text-center">
-                  <div className="grid gap-2" data-testid="approved-applications-count">
-                    <i className="flex justify-center">
-                      <CheckIcon className="bg-teal-400 text-grey-500 rounded-full h-6 w-6 p-1" aria-hidden="true" />
-                    </i>
-                    <span className="text-xs text-grey-400 font-semibold text-center mt-2">APPROVED</span>
-                    <span className="text-grey-500 font-semibold">{selected?.filter(obj => obj.status === "APPROVED").length}</span>
-                  </div>
+                  <ApprovedApplicationsCount grantApplications={selected}/>
                   <span className="text-4xl font-thin">|</span>
-                  <div className="grid gap-2" data-testid="rejected-applications-count">
-                    <i className="flex justify-center">
-                      <XIcon className="bg-pink-500 text-white rounded-full h-6 w-6 p-1" aria-hidden="true" />
-                    </i>
-                    <span className="text-xs text-grey-400 font-semibold text-center mt-2">REJECTED</span>
-                    <span className="text-grey-500 font-semibold">{selected?.filter(obj => obj.status === "REJECTED").length}</span>
-                  </div>
+                  <RejectedApplicationsCount grantApplications={selected}/>
                 </div>
-                <p className="text-sm italic text-grey-400 mb-2">Changes could be subject to additional gas fees.</p>
+                <AdditionalGasFeesNote />
               </>
             }
             confirmButtonAction={handleBulkReview}
@@ -239,3 +160,29 @@ export default function ApplicationsReceived() {
     </div>
   )
 }
+
+function NoApplicationsMessage() {
+  return <>
+    <h2 className="mt-8 text-2xl antialiased">No Applications</h2>
+    <div className="mt-2 text-sm">Applications have not been submitted yet.</div>
+    <div className="text-sm">Try promoting your Grant Program to get more traction!</div>
+  </>;
+}
+
+function Continue(props: { onClick: () => void }) {
+  return <Button
+    type="button"
+    $variant="solid"
+    className="text-sm px-5"
+    onClick={props.onClick}
+  >
+    Continue
+  </Button>;
+}
+
+function NumberOfApplicationsSelectedMessage(props: { grantApplications: GrantApplication[], predicate: (obj: any) => boolean }) {
+  return <span className="text-grey-400 text-sm mr-6">
+    You have selected {props.grantApplications?.filter(props.predicate).length} Grant Applications
+  </span>;
+}
+

--- a/packages/round-manager/src/features/round/BulkApplicationCommon.tsx
+++ b/packages/round-manager/src/features/round/BulkApplicationCommon.tsx
@@ -1,0 +1,150 @@
+import {GrantApplication, ProjectStatus} from "../api/types";
+import {Button} from "../common/styles";
+import {CheckIcon, XIcon} from "@heroicons/react/solid";
+
+export function NumberOfStatus(props: { grantApplications: GrantApplication[], status: ProjectStatus }) {
+	return <>
+		<span className="text-xs text-grey-400 font-semibold text-center mt-2">{props.status}</span>
+		<span
+			className="text-grey-500 font-semibold">{props.grantApplications?.filter(application => application.status === props.status).length}
+    </span>
+	</>;
+}
+
+export function ApplicationLogo(props: { application: any }) {
+	return (
+		<div className="pl-4">
+			<div className="-mt-6 sm:-mt-6 sm:flex sm:items-end sm:space-x-5">
+				<div className="flex">
+					<img
+						className="h-12 w-12 rounded-full ring-4 ring-white bg-white"
+						src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${props.application.project!.logoImg}`}
+						alt=""
+					/>
+				</div>
+			</div>
+		</div>);
+}
+
+export function ApplicationBanner(props: { application: any }) {
+	return <div>
+		<img
+			className="h-[120px] w-full object-cover rounded-t"
+			src={`https://${process.env.REACT_APP_PINATA_GATEWAY}/ipfs/${props.application.project!.bannerImg}`}
+			alt=""
+		/>
+	</div>;
+}
+
+export function AdditionalGasFeesNote() {
+	return <p className="text-sm italic text-grey-400 mb-2">Changes could be subject to additional gas fees.</p>;
+}
+
+function MarkForRejection(props: { checkSelection: "PENDING" | "APPROVED" | "REJECTED" | "APPEAL" | "FRAUD" | undefined, onClick: () => void }) {
+	return <Button
+		type="button"
+		$variant="solid"
+		className={
+			`border border-grey-400 w-9 h-8 p-2.5 ${props.checkSelection === "REJECTED"
+				? "bg-white text-pink-500" : "bg-grey-500 text-white"}`
+		}
+		onClick={props.onClick}
+		data-testid="reject-button"
+	>
+		<XIcon aria-hidden="true"/>
+	</Button>;
+}
+
+function MarkForApproval(props: { applicationStatus?: "PENDING" | "APPROVED" | "REJECTED" | "APPEAL" | "FRAUD", onClick: () => void }) {
+	return <Button
+		type="button"
+		$variant="solid"
+		className={
+			`border border-grey-400 w-9 h-8 p-2.5 ${props.applicationStatus === "APPROVED"
+				? "bg-teal-400 text-grey-500" : "bg-grey-500 text-white"}`
+		}
+		onClick={props.onClick}
+		data-testid="approve-button"
+	>
+		<CheckIcon aria-hidden="true"/>
+	</Button>;
+}
+
+export function ApplicationHeader(props: { bulkSelect: boolean | undefined, applicationStatus: "PENDING" | "APPROVED" | "REJECTED" | "APPEAL" | "FRAUD" | undefined, approveOnClick?: () => void, rejectOnClick?: () => void, application: any }) {
+	return <div className="relative">
+		{props.bulkSelect && (
+			<div className="absolute right-4 top-4 gap-2 flex"
+					 data-testid="bulk-approve-reject-buttons">
+				{props.approveOnClick &&
+					<MarkForApproval applicationStatus={props.applicationStatus} onClick={props.approveOnClick} />}
+				{props.rejectOnClick &&
+					<MarkForRejection checkSelection={props.applicationStatus} onClick={props.rejectOnClick}/>}
+			</div>)}
+		<div>
+			<ApplicationBanner application={props.application}/>
+			<ApplicationLogo application={props.application}/>
+		</div>
+	</div>;
+}
+
+export function Cancel(props: { onClick: () => void }) {
+	return <Button
+		type="button"
+		$variant="outline"
+		className="text-xs text-pink-500"
+		onClick={props.onClick}
+	>
+		Cancel
+	</Button>;
+}
+
+export function Select(props: { onClick: () => void }) {
+	return <Button
+		type="button"
+		$variant="outline"
+		className="text-xs bg-grey-150 border-none"
+		onClick={props.onClick}
+		data-testid="select"
+	>
+		Select
+	</Button>;
+}
+
+export function Continue(props: { grantApplications: GrantApplication[], status: ProjectStatus, onClick: () => void }) {
+	return (
+		<div className="fixed w-full left-0 bottom-0 bg-white">
+			<hr/>
+			<div className="flex justify-end items-center py-5 pr-20">
+        <span className="text-grey-400 text-sm mr-6">
+          You have selected {props.grantApplications?.filter(application => application.status === props.status).length} Grant Applications
+        </span>
+				<Button
+					type="button"
+					$variant="solid"
+					className="text-sm px-5"
+					onClick={props.onClick}
+				>
+					Continue
+				</Button>
+			</div>
+		</div>
+	)
+}
+
+export function RejectedApplicationsCount(props: { grantApplications: GrantApplication[] }) {
+	return <div className="grid gap-2" data-testid="rejected-applications-count">
+		<i className="flex justify-center">
+			<XIcon className="bg-pink-500 text-white rounded-full h-6 w-6 p-1" aria-hidden="true"/>
+		</i>
+		<NumberOfStatus grantApplications={props.grantApplications} status={"REJECTED"}/>
+	</div>;
+}
+
+export function ApprovedApplicationsCount(props: { grantApplications: GrantApplication[] }) {
+	return <div className="grid gap-2" data-testid="approved-applications-count">
+		<i className="flex justify-center">
+			<CheckIcon className="bg-teal-400 text-grey-500 rounded-full h-6 w-6 p-1" aria-hidden="true"/>
+		</i>
+		<NumberOfStatus grantApplications={props.grantApplications} status={"APPROVED"}/>
+	</div>;
+}

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsApproved.test.tsx
@@ -115,7 +115,7 @@ describe("<ApplicationsApproved />", () => {
     });
 
     it("does not display approve options in approved applications tab", () => {
-      renderWrapped(<ApplicationsApproved />)
+      setupInBulkSelectionMode();
       const approveButtons = screen.queryAllByTestId("approve-button")
       expect(approveButtons.length).toEqual(0)
     });
@@ -147,8 +147,6 @@ describe("<ApplicationsApproved />", () => {
     })
   });
 
-
-
   describe("when at least one application is selected", () => {
     let bulkUpdateGrantApplications: any;
 
@@ -162,13 +160,18 @@ describe("<ApplicationsApproved />", () => {
       });
     })
 
-    it("displays the continue option and copy", () => {
+    it("displays the continue option and copy only when an application is rejected", () => {
       setupInBulkSelectionMode();
+
+      let continueButton = screen.queryByRole('button', {
+        name: /Continue/i
+      });
+      expect(continueButton).not.toBeInTheDocument();
 
       const rejectButton = screen.queryAllByTestId("reject-button")[0]
       fireEvent.click(rejectButton)
 
-      const continueButton = screen.getByRole('button', {
+      continueButton = screen.getByRole('button', {
         name: /Continue/i
       });
       expect(continueButton).toBeInTheDocument();
@@ -193,14 +196,6 @@ describe("<ApplicationsApproved />", () => {
       fireEvent.click(continueButton)
 
       expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
-    })
-
-    it('does not show continue when no applications are rejected', () => {
-      const continueButton = screen.queryByRole('button', {
-        name: /Continue/i
-      });
-
-      expect(continueButton).not.toBeInTheDocument();
     })
 
     it('choosing confirm kicks off the signature flow to persist rejected applications', async () => {

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
@@ -5,6 +5,7 @@ import {
   useListGrantApplicationsQuery,
 } from "../../api/services/grantApplication"
 import { makeGrantApplicationData, renderWrapped } from "../../../test-utils"
+import ApplicationsRejected from "../ApplicationsRejected";
 
 jest.mock("../../api/services/grantApplication");
 jest.mock("../../common/Auth", () => ({
@@ -43,7 +44,7 @@ describe("<ApplicationsReceived />", () => {
   })
 
   describe("when there are no approved applications", () => {
-    it("should not display the bulk select button", () => {
+    it("should not display the bulk select option", () => {
       (useListGrantApplicationsQuery as any).mockReturnValue({
         data: [], refetch: jest.fn(), isSuccess: true, isLoading: false
       });
@@ -60,8 +61,9 @@ describe("<ApplicationsReceived />", () => {
   })
 
   describe('when received applications are shown', () => {
-    it("should display the bulk select button", () => {
-      renderWrapped(<ApplicationsReceived />)
+
+    it("should display the bulk select option", () => {
+      renderWrapped(<ApplicationsRejected />)
       expect(screen.getByText(
         'Save in gas fees by approving/rejecting multiple applications at once.'
       )).toBeInTheDocument()
@@ -70,8 +72,8 @@ describe("<ApplicationsReceived />", () => {
       })).toBeInTheDocument()
     });
 
-    it("should display the cancel button when select is clicked", () => {
-      renderWrapped(<ApplicationsReceived />)
+    it("should display the cancel option when select is selected", () => {
+      renderWrapped(<ApplicationsRejected />)
       const selectButton = screen.getByRole('button', {
         name: /Select/i
       });
@@ -84,8 +86,8 @@ describe("<ApplicationsReceived />", () => {
       })).not.toBeInTheDocument()
     });
 
-    it("should display the select button when cancel is clicked", () => {
-      renderWrapped(<ApplicationsReceived />)
+    it("should display the select option when cancel is selected", () => {
+      renderWrapped(<ApplicationsRejected />)
       const selectButton = screen.getByRole('button', {
         name: /Select/i
       });
@@ -126,35 +128,52 @@ describe("<ApplicationsReceived />", () => {
     screen.getByText(grantApplications[2].project!.description)
   })
 
-  describe("when bulkSelect is true", () => {
+  describe("when choosing select", () => {
 
-    beforeEach(() => {
-      // eslint-disable-next-line testing-library/no-render-in-setup
+    it( "renders approve and reject options on each project", () => {
       renderWrapped(<ApplicationsReceived />)
-      const selectButton = screen.getByTestId('select')
-      fireEvent.click(selectButton);
-    })
-
-    it("renders approve and reject buttons on each project card", () => {
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
       expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(grantApplications.length)
     });
 
-    it("displays an approved button as selected when approve button is clicked", () => {
+    it("displays an approved button as selected when approve button is selected", () => {
+      renderWrapped(<ApplicationsReceived />)
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
+
       const approveButton = screen.queryAllByTestId("approve-button")[0]
+
       fireEvent.click(approveButton)
 
       expect(approveButton).toHaveClass("bg-teal-400 text-grey-500")
     });
 
-    it("displays a rejected button as selected when reject button is clicked", () => {
+    it("displays a rejected option as selected when reject option is selected", () => {
+      renderWrapped(<ApplicationsReceived />)
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
+
       const rejectButton = screen.queryAllByTestId("reject-button")[0]
       fireEvent.click(rejectButton)
 
       expect(rejectButton).toHaveClass("bg-white text-pink-500")
     });
 
-    describe("and when an approve button is already selected on a card", () => {
-      it("selects the reject button and unselects the approve button when the reject button is clicked on that card", () => {
+    describe("and when an approve option is already selected", () => {
+      it("selects the reject option and unselects the approve option when the reject option selected", () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
+
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
 
@@ -164,7 +183,14 @@ describe("<ApplicationsReceived />", () => {
         expect(approveButton).not.toHaveClass("bg-teal-400 text-grey-500")
         expect(rejectButton).toHaveClass("bg-white text-pink-500")
       });
-      it("unselects the approve button when that selected approve button is clicked on that card", () => {
+
+      it("unselects the approve option when that selected approve option is selected", () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
+
         const approveButton = screen.queryAllByTestId("approve-button")[0]
 
         fireEvent.click(approveButton)
@@ -174,8 +200,14 @@ describe("<ApplicationsReceived />", () => {
       });
     });
 
-    describe("and when an reject button is already selected on a card", () => {
-      it("selects the approve button and unselects the reject button when the approve button is clicked on that card", () => {
+    describe("and when an reject option is already selected", () => {
+      it("selects the approve button and unselects the reject button when the approve button is selected", () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
+
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
 
@@ -185,7 +217,13 @@ describe("<ApplicationsReceived />", () => {
         expect(approveButton).toHaveClass("bg-teal-400 text-grey-500")
         expect(rejectButton).not.toHaveClass("bg-white text-pink-500")
       });
-      it("unselects the reject button when that selected reject button is clicked on that card", () => {
+      it("unselects the reject option when that selected reject option is selected", () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
+
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
 
         fireEvent.click(rejectButton)
@@ -196,6 +234,12 @@ describe("<ApplicationsReceived />", () => {
     });
 
     it("should approve individual applications independently", () => {
+      renderWrapped(<ApplicationsReceived />)
+      const selectButton = screen.getByRole('button', {
+        name: /Select/i
+      });
+      fireEvent.click(selectButton)
+
       const firstApproveButton = screen.queryAllByTestId("approve-button")[0]
       fireEvent.click(firstApproveButton)
       expect(firstApproveButton).toHaveClass("bg-teal-400 text-grey-500")
@@ -206,7 +250,14 @@ describe("<ApplicationsReceived />", () => {
     });
 
     describe("when at least one application is selected", () => {
-      it("displays the continue button and copy", () => {
+
+
+      it("displays the continue option and copy", () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -223,7 +274,12 @@ describe("<ApplicationsReceived />", () => {
         expect(screen.getByText(/You have selected 2 Grant Applications/i)).toBeInTheDocument();
       })
 
-      it("opens the confirmation modal when the continue button is clicked", async () => {
+      it("opens confirmation when continue is selected", async () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -236,6 +292,11 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("shows the correct number of approved and rejected applications in the confirmation modal", async () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
         fireEvent.click(screen.queryAllByTestId("approve-button")[0])
         fireEvent.click(screen.queryAllByTestId("reject-button")[1])
         fireEvent.click(screen.queryAllByTestId("approve-button")[2])
@@ -252,7 +313,12 @@ describe("<ApplicationsReceived />", () => {
         within(rejectedApplicationsCount).getByText(/1/)
       })
 
-      it("calls bulkUpdateGrantApplications when confirm button is clicked on the modal", async () => {
+      it("calls bulkUpdateGrantApplications when confirm is selected", async () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -271,7 +337,12 @@ describe("<ApplicationsReceived />", () => {
         await waitForElementToBeRemoved(() => screen.queryByTestId("confirm-modal"));
       })
 
-      it("closes the modal when cancel button is clicked on the modal", async () => {
+      it("closes confirmation when cancel is selected", async () => {
+        renderWrapped(<ApplicationsReceived />)
+        const selectButton = screen.getByRole('button', {
+          name: /Select/i
+        });
+        fireEvent.click(selectButton)
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -295,7 +366,7 @@ describe("<ApplicationsReceived />", () => {
   });
 
   describe("when bulkSelect is false", () => {
-    it("does not render approve and reject buttons on each card", () => {
+    it("does not render approve and reject options on each card", () => {
       renderWrapped(<ApplicationsReceived />)
       expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(0)
     });

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsReceived.test.tsx
@@ -5,7 +5,6 @@ import {
   useListGrantApplicationsQuery,
 } from "../../api/services/grantApplication"
 import { makeGrantApplicationData, renderWrapped } from "../../../test-utils"
-import ApplicationsRejected from "../ApplicationsRejected";
 
 jest.mock("../../api/services/grantApplication");
 jest.mock("../../common/Auth", () => ({
@@ -19,6 +18,14 @@ const grantApplications = [
 ];
 
 let bulkUpdateGrantApplications = jest.fn()
+
+function setupInBulkSelectionMode() {
+  renderWrapped(<ApplicationsReceived/>)
+  const selectButton = screen.getByRole('button', {
+    name: /Select/i,
+  })
+  fireEvent.click(selectButton)
+}
 
 describe("<ApplicationsReceived />", () => {
   beforeEach(() => {
@@ -63,7 +70,7 @@ describe("<ApplicationsReceived />", () => {
   describe('when received applications are shown', () => {
 
     it("should display the bulk select option", () => {
-      renderWrapped(<ApplicationsRejected />)
+      renderWrapped(<ApplicationsReceived />)
       expect(screen.getByText(
         'Save in gas fees by approving/rejecting multiple applications at once.'
       )).toBeInTheDocument()
@@ -73,11 +80,7 @@ describe("<ApplicationsReceived />", () => {
     });
 
     it("should display the cancel option when select is selected", () => {
-      renderWrapped(<ApplicationsRejected />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
+      setupInBulkSelectionMode()
       expect(screen.getByRole('button', {
         name: /Cancel/i
       })).toBeInTheDocument()
@@ -87,11 +90,7 @@ describe("<ApplicationsReceived />", () => {
     });
 
     it("should display the select option when cancel is selected", () => {
-      renderWrapped(<ApplicationsRejected />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
+      setupInBulkSelectionMode()
 
       const cancelButton = screen.getByRole('button', {
         name: /Cancel/i
@@ -131,20 +130,13 @@ describe("<ApplicationsReceived />", () => {
   describe("when choosing select", () => {
 
     it( "renders approve and reject options on each project", () => {
-      renderWrapped(<ApplicationsReceived />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
+      setupInBulkSelectionMode()
+
       expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(grantApplications.length)
     });
 
     it("displays an approved button as selected when approve button is selected", () => {
-      renderWrapped(<ApplicationsReceived />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
+      setupInBulkSelectionMode()
 
       const approveButton = screen.queryAllByTestId("approve-button")[0]
 
@@ -154,11 +146,7 @@ describe("<ApplicationsReceived />", () => {
     });
 
     it("displays a rejected option as selected when reject option is selected", () => {
-      renderWrapped(<ApplicationsReceived />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
+      setupInBulkSelectionMode()
 
       const rejectButton = screen.queryAllByTestId("reject-button")[0]
       fireEvent.click(rejectButton)
@@ -168,11 +156,7 @@ describe("<ApplicationsReceived />", () => {
 
     describe("and when an approve option is already selected", () => {
       it("selects the reject option and unselects the approve option when the reject option selected", () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
 
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
@@ -185,11 +169,7 @@ describe("<ApplicationsReceived />", () => {
       });
 
       it("unselects the approve option when that selected approve option is selected", () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
 
         const approveButton = screen.queryAllByTestId("approve-button")[0]
 
@@ -202,11 +182,7 @@ describe("<ApplicationsReceived />", () => {
 
     describe("and when an reject option is already selected", () => {
       it("selects the approve button and unselects the reject button when the approve button is selected", () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
 
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
@@ -218,11 +194,7 @@ describe("<ApplicationsReceived />", () => {
         expect(rejectButton).not.toHaveClass("bg-white text-pink-500")
       });
       it("unselects the reject option when that selected reject option is selected", () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
 
         const rejectButton = screen.queryAllByTestId("reject-button")[0]
 
@@ -234,11 +206,7 @@ describe("<ApplicationsReceived />", () => {
     });
 
     it("should approve individual applications independently", () => {
-      renderWrapped(<ApplicationsReceived />)
-      const selectButton = screen.getByRole('button', {
-        name: /Select/i
-      });
-      fireEvent.click(selectButton)
+      setupInBulkSelectionMode()
 
       const firstApproveButton = screen.queryAllByTestId("approve-button")[0]
       fireEvent.click(firstApproveButton)
@@ -251,13 +219,9 @@ describe("<ApplicationsReceived />", () => {
 
     describe("when at least one application is selected", () => {
 
-
       it("displays the continue option and copy", () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
+
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -275,11 +239,8 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("opens confirmation when continue is selected", async () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
+
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -292,11 +253,8 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("shows the correct number of approved and rejected applications in the confirmation modal", async () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
+
         fireEvent.click(screen.queryAllByTestId("approve-button")[0])
         fireEvent.click(screen.queryAllByTestId("reject-button")[1])
         fireEvent.click(screen.queryAllByTestId("approve-button")[2])
@@ -314,11 +272,8 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("calls bulkUpdateGrantApplications when confirm is selected", async () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
+
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 
@@ -338,11 +293,8 @@ describe("<ApplicationsReceived />", () => {
       })
 
       it("closes confirmation when cancel is selected", async () => {
-        renderWrapped(<ApplicationsReceived />)
-        const selectButton = screen.getByRole('button', {
-          name: /Select/i
-        });
-        fireEvent.click(selectButton)
+        setupInBulkSelectionMode()
+
         const approveButton = screen.queryAllByTestId("approve-button")[0]
         fireEvent.click(approveButton)
 

--- a/packages/round-manager/src/features/round/__tests__/ApplicationsRejected.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsRejected.test.tsx
@@ -53,7 +53,8 @@ describe("<ApplicationsRejected />", () => {
   })
 
   describe('when rejected applications are shown', () => {
-    it("should display the bulk select button", () => {
+
+    it("should display bulk select", () => {
       renderWrapped(<ApplicationsRejected />)
       expect(screen.getByText(
         'Save in gas fees by approving/rejecting multiple applications at once.'
@@ -63,7 +64,7 @@ describe("<ApplicationsRejected />", () => {
       })).toBeInTheDocument()
     });
 
-    it("should display the cancel button when select is clicked", () => {
+    it("should display the cancel option when select is selected", () => {
       renderWrapped(<ApplicationsRejected />)
       const selectButton = screen.getByRole('button', {
         name: /Select/i
@@ -77,7 +78,7 @@ describe("<ApplicationsRejected />", () => {
       })).not.toBeInTheDocument()
     });
 
-    it("should display the select button when cancel is clicked", () => {
+    it("should display the select option when cancel is selected", () => {
       renderWrapped(<ApplicationsRejected />)
       const selectButton = screen.getByRole('button', {
         name: /Select/i
@@ -99,7 +100,7 @@ describe("<ApplicationsRejected />", () => {
   })
 
   describe("when there are no approved applications", () => {
-    it("should not display the bulk select button", () => {
+    it("should not display the bulk select option", () => {
       (useListGrantApplicationsQuery as any).mockReturnValue({
         data: [], refetch: jest.fn(), isSuccess: true, isLoading: false
       });
@@ -115,28 +116,25 @@ describe("<ApplicationsRejected />", () => {
     })
   })
 
-  describe("when bulkSelect is true", () => {
+  describe("when bulk select is active", () => {
     it("renders approve buttons on each project card", () => {
-      renderWrapped(<ApplicationsRejected />);
-      const select = screen.getByTestId('select-button');
+      renderWrapped(<ApplicationsRejected />)
+      const select = screen.getByTestId('select');
       fireEvent.click(select);
 
       expect(screen.queryAllByTestId("approve-button"))
         .toHaveLength(grantApplications.length);
     });
 
-    it("does not display reject buttons in rejected applications tab", () => {
+    it("does not display reject options in rejected applications tab", () => {
       renderWrapped(<ApplicationsRejected />)
-      const select = screen.getByTestId('select-button');
-      fireEvent.click(select);
-
       const rejectButtons = screen.queryAllByTestId("reject-button")
       expect(rejectButtons.length).toEqual(0)
     });
 
-    it("selects an approved button when approve button is clicked", () => {
+    it("selects an approved option", () => {
       renderWrapped(<ApplicationsRejected />)
-      const select = screen.getByTestId('select-button');
+      const select = screen.getByTestId('select');
       fireEvent.click(select);
       const approveButton = screen.queryAllByTestId("approve-button")[0]
       fireEvent.click(approveButton)
@@ -144,9 +142,9 @@ describe("<ApplicationsRejected />", () => {
       expect(approveButton).toHaveClass("bg-teal-400 text-grey-500")
     });
 
-    it("unselects an approve button when a selected approve button is clicked", () => {
+    it("unselects an approve option", () => {
       renderWrapped(<ApplicationsRejected />)
-      const select = screen.getByTestId('select-button');
+      const select = screen.getByTestId('select');
       fireEvent.click(select);
 
       const approveButton = screen.queryAllByTestId("approve-button")[0]
@@ -157,7 +155,7 @@ describe("<ApplicationsRejected />", () => {
     });
   });
 
-  describe("when bulkSelect is false", () => {
+  describe("when bulk select is inactive", () => {
     it("does not render approve and reject buttons on each card", () => {
       renderWrapped(<ApplicationsRejected />)
       expect(screen.queryAllByTestId("bulk-approve-reject-buttons")).toHaveLength(0)
@@ -177,9 +175,9 @@ describe("<ApplicationsRejected />", () => {
       });
     })
 
-    it("displays the continue button and copy", () => {
+    it("displays the continue option and copy", () => {
       renderWrapped(<ApplicationsRejected />)
-      const select = screen.getByTestId('select-button');
+      const select = screen.getByTestId('select');
       fireEvent.click(select);
 
       const approveButton = screen.queryAllByTestId("approve-button")[0]
@@ -198,9 +196,9 @@ describe("<ApplicationsRejected />", () => {
       expect(screen.getByText(/You have selected 2 Grant Applications/i)).toBeInTheDocument();
     })
 
-    it("opens the confirmation modal when the continue button is clicked", async () => {
+    it("opens confirmation when the continue is selected", async () => {
       renderWrapped(<ApplicationsRejected />)
-      const select = screen.getByTestId('select-button');
+      const select = screen.getByTestId('select');
       fireEvent.click(select);
 
       const approveButton = screen.queryAllByTestId("approve-button")[0]
@@ -214,9 +212,7 @@ describe("<ApplicationsRejected />", () => {
       expect(screen.getByTestId("confirm-modal")).toBeInTheDocument();
     })
 
-    it('does not show continue button when no applications are rejected', () => {
-      renderWrapped(<ApplicationsRejected />)
-
+    it('does not show continue option when no applications are rejected', () => {
       const continueButton = screen.queryByRole('button', {
         name: /Continue/i
       });
@@ -225,8 +221,8 @@ describe("<ApplicationsRejected />", () => {
     })
 
     it('choosing confirm kicks off the signature flow to persist approved applications', async () => {
-      renderWrapped(<ApplicationsRejected/>)
-      const select = screen.getByTestId('select-button');
+      renderWrapped(<ApplicationsRejected />)
+      const select = screen.getByTestId('select');
       fireEvent.click(select);
 
       const approveButton = screen.queryAllByTestId("approve-button")[0]
@@ -260,9 +256,9 @@ describe("<ApplicationsRejected />", () => {
       });
     })
 
-    it("closes the modal when cancel button is clicked on the modal", async () => {
+    it("closes confirmation when cancel is selected", async () => {
       renderWrapped(<ApplicationsRejected />)
-      const select = screen.getByTestId('select-button');
+      const select = screen.getByTestId('select');
       fireEvent.click(select);
 
       const approveButton = screen.queryAllByTestId("approve-button")[0]


### PR DESCRIPTION
refactor: move button and icon to MarkForApproval component 
tests: just send in bulk select state as if it was already clicked 
refactor: extract cancel and select button JSX to well named components 
refactor: extract no apps message JSX to well named component 
refactor: extract continue and number of apps selected message JSX to well named components 
refactor: extract count of rejected and count of approved JSX to well named components
refactor: extract number of approve / reject JSX into generic component called NumberOfStatus 
refactor: moved back state for bulk select status to be internal to applications received again 
refactor: extract jsx to new well named components ApprovedApplicationsCount and RejectedApplicationsCount 
refactor: move text for additional gas fees to shared AdditionalGasFeesNote component 
refactor: reuse ApplicationHeader in ApplicationsApproved

closes #303