### PR TITLE
feat: add ViewRoundPage

### DIFF
--- a/packages/grant-explorer/package.json
+++ b/packages/grant-explorer/package.json
@@ -76,6 +76,7 @@
     ]
   },
   "devDependencies": {
+    "@faker-js/faker": "^7.5.0",
     "autoprefixer": "^10.4.7",
     "postcss": "^8.4.14",
     "tailwind-styled-components": "^2.1.7",

--- a/packages/grant-explorer/src/context/RoundContext.tsx
+++ b/packages/grant-explorer/src/context/RoundContext.tsx
@@ -1,0 +1,129 @@
+import { createContext, useContext, useEffect, useReducer } from "react";
+import { getRoundById } from "../features/api/round";
+import { Round } from "../features/api/types";
+
+export interface RoundState {
+  rounds: Round[];
+  isLoading: boolean;
+  listRoundsError?: Error;
+  getRoundByIdError?: Error;
+}
+
+enum ActionType {
+  SET_LOADING = "SET_LOADING",
+  FINISH_LOADING = "FINISH_LOADING",
+  SET_ROUNDS = "SET_ROUNDS",
+  SET_ERROR_LIST_ROUNDS = "SET_ERROR_LIST_ROUNDS",
+  ADD_ROUND = "ADD_ROUND",
+  SET_ERROR_GET_ROUND = "SET_ERROR_GET_ROUND",
+}
+
+interface Action {
+  type: ActionType;
+  payload?: any;
+}
+
+type Dispatch = (action: Action) => void;
+
+export const initialRoundState: RoundState = {
+  rounds: [],
+  isLoading: false,
+};
+
+export const RoundContext = createContext<
+  { state: RoundState; dispatch: Dispatch } | undefined
+>(undefined);
+
+const roundReducer = (state: RoundState, action: Action) => {
+  switch (action.type) {
+    case ActionType.SET_LOADING:
+      return { ...state, isLoading: action.payload };
+    case ActionType.FINISH_LOADING:
+      return { ...state, isLoading: false };
+    case ActionType.SET_ROUNDS:
+      return {
+        ...state,
+        rounds: action.payload ?? [],
+        listRoundsError: undefined,
+      };
+    case ActionType.SET_ERROR_LIST_ROUNDS:
+      return { ...state, rounds: [], listRoundsError: action.payload };
+    case ActionType.ADD_ROUND:
+      return {
+        ...state,
+        rounds: state.rounds.concat(action.payload),
+        getRoundByIdError: undefined,
+      };
+    case ActionType.SET_ERROR_GET_ROUND:
+      return { ...state, getRoundByIdError: action.payload };
+    default:
+      return state;
+  }
+};
+
+export const RoundProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [state, dispatch] = useReducer(roundReducer, initialRoundState);
+
+  const providerProps = {
+    state,
+    dispatch,
+  };
+
+  return (
+    <RoundContext.Provider value={providerProps}>
+      {children}
+    </RoundContext.Provider>
+  );
+};
+
+
+function fetchRoundsById(dispatch: Dispatch, chainId: string, roundId: string) {
+  dispatch({ type: ActionType.SET_LOADING, payload: true });
+
+  getRoundById(roundId, chainId)
+    .then((round) =>
+      dispatch({ type: ActionType.ADD_ROUND, payload: round })
+    )
+    .catch((error) =>
+      dispatch({ type: ActionType.SET_ERROR_GET_ROUND, payload: error })
+    )
+    .finally(() =>
+      dispatch({ type: ActionType.FINISH_LOADING })
+    );
+}
+
+export const useRoundById = (
+  chainId: string,
+  roundId: string
+): {
+  round?: Round;
+  isLoading: boolean;
+  getRoundByIdError?: Error;
+} => {  
+  const context = useContext(RoundContext);
+  if (context === undefined) {
+    throw new Error("useRoundById must be used within a RoundProvider");
+  }
+
+  useEffect(() => {
+    if (roundId) {
+      const existingRound = context.state.rounds.find(
+        (round) => round.id === roundId
+      );
+
+      if (!existingRound) {
+        fetchRoundsById(context.dispatch, chainId, roundId);
+      }
+    }
+  }, [chainId, roundId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return {
+    round: context.state.rounds.find((round) => round.id === roundId),
+    isLoading: context.state.isLoading,
+    getRoundByIdError: context.state.getRoundByIdError,
+  };
+}

--- a/packages/grant-explorer/src/context/__tests__/RoundContext.test.tsx
+++ b/packages/grant-explorer/src/context/__tests__/RoundContext.test.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  useRoundById,
+  RoundProvider,
+} from "../RoundContext";
+import { render, screen, waitFor } from "@testing-library/react";
+import { makeRoundData } from "../../test-utils";
+import { getRoundById } from "../../features/api/round";
+import { Round } from "../../features/api/types";
+
+jest.mock("../../features/api/round");
+jest.mock("wagmi");
+jest.mock("@rainbow-me/rainbowkit", () => ({
+  ConnectButton: jest.fn(),
+}));
+
+describe("<ListRoundProvider />", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("useRoundById()", () => {
+    it("provides round based on given round id", async () => {
+      const expectedRound = makeRoundData();
+      const expectedRoundId: string = expectedRound.id!;
+      (getRoundById as any).mockResolvedValue(expectedRound);
+
+      render(
+        <RoundProvider>
+          <TestingUseRoundByIdComponent
+            expectedRoundId={expectedRoundId}
+          />
+        </RoundProvider>
+      );
+
+      expect(await screen.findByText(expectedRoundId)).toBeInTheDocument();
+    });
+
+    it("sets isLoading to true when getRoundById call is in progress", async () => {
+      const expectedRound = makeRoundData();
+      const expectedRoundId: string = expectedRound.id!;
+      (getRoundById as any).mockReturnValue(new Promise<Round>(() => {}));
+
+      render(
+        <RoundProvider>
+          <TestingUseRoundByIdComponent
+            expectedRoundId={expectedRoundId}
+          />
+        </RoundProvider>
+      );
+
+      expect(
+        await screen.findByTestId("is-loading-round-by-id")
+      ).toBeInTheDocument();
+    });
+
+    it("sets isLoading back to false and when getRoundById call succeeds", async () => {
+      const expectedRound = makeRoundData();
+      const expectedRoundId: string = expectedRound.id!;
+      (getRoundById as any).mockResolvedValue(expectedRound);
+
+      render(
+        <RoundProvider>
+          <TestingUseRoundByIdComponent
+            expectedRoundId={expectedRoundId}
+          />
+        </RoundProvider>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("is-loading-round-by-id")
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("sets isLoading back to false when getRoundById call fails", async () => {
+      const expectedRound = makeRoundData();
+      const expectedRoundId: string = expectedRound.id!;
+      (getRoundById as any).mockRejectedValue(new Error(":("));
+
+      render(
+        <RoundProvider>
+          <TestingUseRoundByIdComponent
+            expectedRoundId={expectedRoundId}
+          />
+        </RoundProvider>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId("is-loading-round-by-id")
+        ).not.toBeInTheDocument();
+      });
+
+      screen.getByTestId("round-by-id-error-msg");
+    });
+  });
+});
+
+
+const TestingUseRoundByIdComponent = (props: {
+  expectedRoundId?: string;
+}) => {
+  if (!props.expectedRoundId) return(<></>)
+
+  const { round, isLoading, getRoundByIdError } = useRoundById(
+    "chainID",
+    props.expectedRoundId
+  );
+  return (
+    <>
+      {round ? <div>{round.id}</div> : <div>No Round Found</div>}
+
+      {isLoading && <div data-testid="is-loading-round-by-id"></div>}
+
+      {getRoundByIdError && <div data-testid="round-by-id-error-msg" />}
+    </>
+  );
+};
+
+function renderWithProvider() {
+  render(
+    <RoundProvider>
+      <TestingUseRoundByIdComponent />
+    </RoundProvider>
+  );
+}

--- a/packages/grant-explorer/src/features/api/round.ts
+++ b/packages/grant-explorer/src/features/api/round.ts
@@ -1,0 +1,61 @@
+import { fetchFromIPFS, graphql_fetch } from "./utils";
+import { Round } from "./types";
+
+
+export async function getRoundById(
+  roundId: string,
+  chainId: any
+): Promise<Round> {
+  try {
+    // get the subgraph for round by $roundId
+    const res = await graphql_fetch(
+      `
+        query GetRoundById($roundId: String) {
+          rounds(where: {
+            id: $roundId
+          }) {
+            id
+            program {
+              id
+            }
+            roundMetaPtr {
+              protocol
+              pointer
+            }
+            applicationMetaPtr {
+              protocol
+              pointer
+            }
+            applicationsStartTime
+            applicationsEndTime
+            roundStartTime
+            roundEndTime
+          }
+        }
+      `,
+      chainId,
+      { roundId }
+    );
+
+    const round = res.data.rounds[0];
+
+    const roundMetadata = await fetchFromIPFS(round.roundMetaPtr.pointer);
+
+    return {
+      id: roundId,
+      roundMetadata,
+      applicationsStartTime: new Date(
+        round.applicationsStartTime * 1000
+      ),
+      applicationsEndTime: new Date(round.applicationsEndTime * 1000),
+      roundStartTime: new Date(round.roundStartTime * 1000),
+      roundEndTime: new Date(round.roundEndTime * 1000),
+      token: round.token,
+      votingStrategy: round.votingStrategy,
+      ownedBy: round.program.id,
+    };
+  } catch (err) {
+    console.log("error", err);
+    throw Error("Unable to fetch round");
+  }
+}

--- a/packages/grant-explorer/src/features/api/types.ts
+++ b/packages/grant-explorer/src/features/api/types.ts
@@ -17,14 +17,14 @@ export interface Web3Instance {
   signer?: any;
 }
 
-export interface Metadata {
+export interface MetadataPointer {
   /**
    * The decentralized storage protocol
    * Read more here: https://github.com/gitcoinco/grants-round/blob/main/packages/contracts/docs/MetaPtrProtocol.md
    */
   protocol: number;
   /**
-   * The identifier which represents metadata on a decentralized storage
+   * The identifier which represents the program metadata on a decentralized storage
    */
   pointer: string;
 }
@@ -53,4 +53,53 @@ export interface Contract {
    * Contract ABI in Human Readable ABI format
    */
   abi: Array<string>;
+}
+
+export interface Round {
+  /**
+   * The on-chain unique round ID
+   */
+  id?: string;
+  /**
+   * Metadata of the Round to be stored off-chain
+   */
+  roundMetadata?: {
+    name: string;
+  };
+  /**
+   * Pointer to round metadata in a decentralized storage e.g IPFS, Ceramic etc.
+   */
+  store?: MetadataPointer;
+  /**
+   * Pointer to application metadata in a decentralized storage e.g IPFS, Ceramic etc.
+   */
+  applicationStore?: MetadataPointer;
+  /**
+   * Voting contract address
+   */
+  votingStrategy: string;
+  /**
+   * Unix timestamp of the start of the round
+   */
+  roundStartTime: Date;
+  /**
+   * Unix timestamp of the end of the round
+   */
+  roundEndTime: Date;
+  /**
+   * Unix timestamp of when grants can apply to a round
+   */
+  applicationsStartTime: Date;
+  /**
+   * Unix timestamp after which grants cannot apply to a round
+   */
+  applicationsEndTime: Date;
+  /**
+   * Contract address of the token used to payout match amounts at the end of a round
+   */
+  token: string;
+  /**
+   * Contract address of the program to which the round belongs
+   */
+  ownedBy: string;
 }

--- a/packages/grant-explorer/src/features/api/utils.ts
+++ b/packages/grant-explorer/src/features/api/utils.ts
@@ -1,5 +1,69 @@
 import { IPFSObject } from "./types"
 
+export enum ChainId {
+  GOERLI_CHAIN_ID = 5,
+  OPTIMISM_MAINNET_CHAIN_ID = 10,
+  OPTIMISM_KOVAN_CHAIN_ID = 69,
+}
+
+/**
+ * Fetch subgraph network for provided web3 network
+ *
+ * @param chainId - The chain ID of the blockchain2
+ * @returns the subgraph endpoint
+ */
+const getGraphQLEndpoint = async (chainId: ChainId) => {
+  let endpoint;
+
+  switch (chainId) {
+    case ChainId.OPTIMISM_MAINNET_CHAIN_ID: {
+      endpoint = `${process.env.REACT_APP_SUBGRAPH_OPTIMISM_MAINNET_API}`;
+      break;
+    }
+    case ChainId.OPTIMISM_KOVAN_CHAIN_ID: {
+      endpoint = `${process.env.REACT_APP_SUBGRAPH_OPTIMISM_KOVAN_API}`;
+      break;
+    }
+    case ChainId.GOERLI_CHAIN_ID:
+    default: {
+      endpoint = `${process.env.REACT_APP_SUBGRAPH_GOERLI_API}`;
+    }
+  }
+
+  return endpoint;
+};
+
+/**
+ * Fetch data from a GraphQL endpoint
+ *
+ * @param query - The query to be executed
+ * @param chainId - The chain ID of the blockchain indexed by the subgraph
+ * @param variables - The variables to be used in the query
+ * @returns The result of the query
+ */
+export const graphql_fetch = async (
+  query: string,
+  chainId: ChainId,
+  variables: object = {}
+) => {
+  const endpoint = await getGraphQLEndpoint(chainId);
+
+  return fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  }).then((resp) => {
+    if (resp.ok) {
+      return resp.json();
+    }
+
+    return Promise.reject(resp);
+  });
+};
+
+
 /**
  * Fetch data from IPFS
  * TODO: include support for fetching abitrary data e.g images

--- a/packages/grant-explorer/src/features/common/Spinner.tsx
+++ b/packages/grant-explorer/src/features/common/Spinner.tsx
@@ -1,13 +1,36 @@
 type SpinnerProps = {
-  text: string
-}
+  text: string;
+};
 
 export function Spinner(props: SpinnerProps) {
   return (
-    <div className="flex h-screen">
-      <div className="m-auto">
-        <p>{props.text}</p>
+    <div className="w-screen" data-testid="loading-spinner">
+      <div className="mt-7 md:mt-28 flex flex-col gap-10 items-center">
+        <LoadingRing className="animate-spin" />
+        <div>
+          <h4 className="mb-2 text-center">Loading...</h4>
+          <p className="text-sm text-grey-400 text-center">{props.text}</p>
+        </div>
       </div>
     </div>
-  )
+  );
 }
+
+const LoadingRing = (props: { className?: string }) => (
+  <svg
+    className={props.className}
+    data-testid="spinner-logo"
+    width="36"
+    height="36"
+    viewBox="0 0 36 36"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <circle cx="18" cy="18" r="16" stroke="#E2E0E7" strokeWidth="4" />
+    <path
+      d="M34 18C34 26.8366 26.8366 34 18 34"
+      stroke="#0E0333"
+      strokeWidth="4"
+    />
+  </svg>
+);

--- a/packages/grant-explorer/src/features/common/__tests__/Spinner.test.tsx
+++ b/packages/grant-explorer/src/features/common/__tests__/Spinner.test.tsx
@@ -1,0 +1,24 @@
+import { Spinner } from "../Spinner";
+import { render, screen } from "@testing-library/react";
+
+describe("<Spinner/>", () => {
+  it("should display spinning logo", () => {
+    render(<Spinner text={""}></Spinner>);
+
+    expect(screen.getByTestId("spinner-logo")).toBeInTheDocument();
+  });
+
+  it("should display 'Loading...' text", () => {
+    render(<Spinner text={""}></Spinner>);
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("should display given subtitle text", () => {
+    const text = "Time to Spin";
+
+    render(<Spinner text={text}></Spinner>);
+
+    expect(screen.getByText(text)).toBeInTheDocument();
+  });
+});

--- a/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
@@ -1,10 +1,52 @@
-export default function ViewRoundPage() {
+import { datadogLogs } from "@datadog/browser-logs";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useRoundById } from "../../context/RoundContext";
+import Footer from "../common/Footer";
+import Navbar from "../common/Navbar";
+import NotFoundPage from "../common/NotFoundPage";
+import { Spinner } from "../common/Spinner";
+
+export default function ViewRound() {
+
+  datadogLogs.logger.info("====> Route: /round/:chainId/:roundId");
+  datadogLogs.logger.info(`====> URL: ${window.location.href}`);
+
+  const { chainId, roundId } = useParams();
+
+  const { round, isLoading } = useRoundById(chainId!, roundId!);
+
+  const [roundExists, setRoundExists] = useState(true);
+  useEffect(() => {
+    setRoundExists(!!round)
+  }, [round]);
 
   return (
-    <div className="container mx-auto px-4 py-16 h-screen">
-      <main>
-        <p>This page shows a list of rounds</p>
-      </main>
-    </div>
+    isLoading ? (
+      <Spinner text="We're fetching the Round." />
+    ) :
+    (
+      <>
+        {!roundExists && <NotFoundPage />}
+        {roundExists &&
+          <>
+          <Navbar />
+            <div className="container mx-auto px-4 py-16 h-screen">
+              <main>
+                <p>
+                  <span>Round Name: </span>
+                  <span>{round?.roundMetadata!.name}</span>
+                </p>
+                <p>
+                  <span>Program: </span>
+                  <span>{round?.ownedBy}</span>
+                </p>
+              </main>
+            </div>
+          <Footer />
+          </>
+        }
+      </>
+    )
   )
 }

--- a/packages/grant-explorer/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -1,0 +1,55 @@
+import ViewRound from "../ViewRoundPage";
+import { screen } from "@testing-library/react";
+import {
+  makeRoundData,
+  renderWithContext,
+} from "../../../test-utils";
+import { faker } from "@faker-js/faker";
+import { Round } from "../../api/types";
+
+const chainId = faker.datatype.number();
+const roundId = faker.finance.ethereumAddress();
+const useParamsFn = () => ({ chainId: chainId, roundId: roundId });
+
+jest.mock("../../common/Navbar");
+jest.mock("../../common/Auth");
+jest.mock("@rainbow-me/rainbowkit", () => ({
+  ConnectButton: jest.fn(),
+}));
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: useParamsFn,
+}));
+
+describe("<ViewRound />", () => {
+  let stubRound: Round;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    stubRound = makeRoundData({id: roundId});
+  });
+
+  it("should display 404 when round is not found", () => {
+    renderWithContext(<ViewRound />, { rounds: [], isLoading: false });
+    expect(screen.getByText("404 ERROR")).toBeInTheDocument();
+  });
+
+  it("displays the round name", async () => {
+    renderWithContext(<ViewRound />, { rounds: [stubRound] });
+
+    await screen.findByText(stubRound.roundMetadata!.name);
+  });
+
+  it("displays program address", async () => {
+    renderWithContext(<ViewRound />, { rounds: [stubRound] });
+
+    await screen.findByText(stubRound.ownedBy);
+  });
+
+  it("displays a loading spinner if loading", () => {
+    renderWithContext(<ViewRound />, { isLoading: true });
+
+    screen.getByTestId("loading-spinner");
+  });
+});

--- a/packages/grant-explorer/src/history.ts
+++ b/packages/grant-explorer/src/history.ts
@@ -1,4 +1,4 @@
-import { createBrowserHistory } from "history"
+import { createHashHistory } from "history"
 
-const history = createBrowserHistory()
+const history = createHashHistory()
 export default history

--- a/packages/grant-explorer/src/index.tsx
+++ b/packages/grant-explorer/src/index.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import ReactDOM from "react-dom/client"
 import { Provider } from "react-redux"
 import { ReduxRouter } from "@lagunovsky/redux-react-router"
+import { RoundProvider } from "./context/RoundContext"
 import { Route, Routes } from "react-router-dom"
 import { WagmiConfig } from "wagmi"
 import { RainbowKitProvider } from '@rainbow-me/rainbowkit'
@@ -19,7 +20,7 @@ import "./index.css"
 import Auth from "./features/common/Auth"
 import NotFound from "./features/common/NotFoundPage"
 import AccessDenied from "./features/common/AccessDenied"
-import ViewRoundPage from "./features/round/ViewRoundPage"
+import ViewRound from "./features/round/ViewRoundPage"
 
 // Initialize datadog
 initDatadog()
@@ -43,7 +44,14 @@ root.render(
                 <Route path="/" element={<NotFound />} />
 
                 {/* Round Routes */}
-                <Route path="/round/:id" element={<ViewRoundPage />} />
+                <Route 
+                  path="/round/:chainId/:roundId" 
+                  element={
+                    <RoundProvider>
+                      <ViewRound />
+                    </RoundProvider>
+                  }
+                />
 
                 {/* Access Denied */}
                 <Route path="/access-denied" element={<AccessDenied />} />

--- a/packages/grant-explorer/src/test-utils.tsx
+++ b/packages/grant-explorer/src/test-utils.tsx
@@ -1,0 +1,45 @@
+import { faker } from "@faker-js/faker";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { initialRoundState, RoundContext, RoundState } from "./context/RoundContext";
+import { Round } from "./features/api/types";
+
+export const makeRoundData = (overrides: Partial<Round> = {}): Round => {
+  const applicationsStartTime = faker.date.soon();
+  const applicationsEndTime = faker.date.soon(10, applicationsStartTime);
+  const roundStartTime = faker.date.future(1, applicationsEndTime);
+  const roundEndTime = faker.date.soon(21, roundStartTime);
+  return {
+    id: faker.finance.ethereumAddress(),
+    roundMetadata: {
+      name: faker.company.name(),
+    },
+    applicationsStartTime,
+    applicationsEndTime,
+    roundStartTime,
+    roundEndTime,
+    token: faker.finance.ethereumAddress(),
+    votingStrategy: faker.finance.ethereumAddress(),
+    ownedBy: faker.finance.ethereumAddress(),
+    ...overrides,
+  };
+};
+
+export const renderWithContext = (
+  ui: JSX.Element,
+  programStateOverrides: Partial<RoundState> = {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dispatch: any = jest.fn()
+) =>
+  render(
+    <MemoryRouter>
+      <RoundContext.Provider
+        value={{
+          state: { ...initialRoundState, ...programStateOverrides },
+          dispatch,
+        }}
+      >
+        {ui}
+      </RoundContext.Provider>
+    </MemoryRouter>
+  );

--- a/packages/grant-explorer/yarn.lock
+++ b/packages/grant-explorer/yarn.lock
@@ -1707,6 +1707,11 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.0"
 
+"@faker-js/faker@^7.5.0":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.5.0.tgz#8e8265f65f5b68d2a57886d59b03788eeb676264"
+  integrity sha512-8wNUCCUHvfvI0gQpDUho/3gPzABffnCn5um65F8dzQ86zz6dlt4+nmAA7PQUc8L+eH+9RgR/qzy5N/8kN0Ozdw==
+
 "@heroicons/react@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.6.tgz#35dd26987228b39ef2316db3b1245c42eb19e324"


### PR DESCRIPTION
##### Description

- add RoundContext and api/round to be fetch data from graph
- add ViewRoundPage with NotFound + nav + footer
- populate ViewRoundPage with RoundContext
- add faker package
- move api/__tests__/utils.test.ts -> api/utils.test.tsx

##### Refers/Fixes

fixes: https://github.com/gitcoinco/grants-round/issues/348

##### Testing


https://bafybeicqnyconodzgott5lcokpw6is3e4oahd4vp5fpjxrcnt3lji4qqmm.on.fleek.co/#/round/5/0xa89c6f804579864e29fdbb9653f62d761d1a42fe
