### PR TITLE
fix: keep copy to clipboard button at the same width through the animation

### DIFF
--- a/packages/round-manager/src/features/common/CopyToClipboardButton.tsx
+++ b/packages/round-manager/src/features/common/CopyToClipboardButton.tsx
@@ -9,14 +9,14 @@ type CopyToClipboardType = {
 };
 
 export default function CopyToClipboardButton(props: CopyToClipboardType) {
-
   const [active, setActive] = useState(false);
 
   return (
-
     <Button
       type="button"
-      className={`inline-flex bg-violet-100 text-violet-600 ${active && 'animate-[violetTransition_20s_ease-in]'} ${props.styles}`}
+      className={`inline-flex bg-violet-100 text-violet-600 w-40 justify-center ${
+        active && "animate-[violetTransition_20s_ease-in]"
+      } ${props.styles}`}
       onClick={async () => {
         setActive(true);
         setTimeout(() => setActive(false), 1000);
@@ -25,7 +25,7 @@ export default function CopyToClipboardButton(props: CopyToClipboardType) {
       }}
     >
       <ClipboardCopyIcon className={props.iconStyle} aria-hidden="true" />
-      { active ? "Copied to clipboard" : "Copy to clipboard" }
+      {active ? "Copied to clipboard" : "Copy to clipboard"}
     </Button>
   );
 }

--- a/packages/round-manager/tailwind.config.js
+++ b/packages/round-manager/tailwind.config.js
@@ -49,16 +49,16 @@ module.exports = {
       },
       keyframes: {
         violetTransition: {
-          '5%': {
-            'background-color': "#F0EBFF",
-            'color': "#6F3FF5",
+          "5%": {
+            "background-color": "#F0EBFF",
+            color: "#6F3FF5",
           },
-          '0%, 80%': {
-            'background-color': "#6F3FF5",
-            'color': "#FFF",
+          "0%, 80%": {
+            "background-color": "#6F3FF5",
+            color: "#FFF",
           },
-        }
-      }
+        },
+      },
     },
   },
   plugins: [require("@tailwindcss/forms"), require("@tailwindcss/line-clamp")],


### PR DESCRIPTION
fix: keep copy to clipboard button at the same width through the animation

fix #396
