### PR TITLE
feat(applicationMetadata): add input types

### DIFF
--- a/packages/round-manager/src/features/api/__tests__/utils.test.ts
+++ b/packages/round-manager/src/features/api/__tests__/utils.test.ts
@@ -365,7 +365,7 @@ describe("generateApplicationSchema", () => {
     expect(schema).toContainEqual({
       id: 2,
       question: "Funding Source",
-      type: "TEXT",
+      type: "text",
       required: true,
       info: "What platforms have you raised funds from?",
       choices: [],
@@ -389,7 +389,7 @@ describe("generateApplicationSchema", () => {
     expect(schema).toContainEqual({
       id: 2,
       question: "Funding Source",
-      type: "TEXT",
+      type: "text",
       required: true,
       info: "What platforms have you raised funds from?",
       choices: [],
@@ -398,7 +398,7 @@ describe("generateApplicationSchema", () => {
     expect(schema).toContainEqual({
       id: 3,
       question: "Ofac",
-      type: "TEXT",
+      type: "text",
       required: true,
       info: "Is you project OFAC compliant?",
       choices: [],

--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -140,10 +140,22 @@ const camelToTitle = (camelCase: string) =>
 export const abbreviateAddress = (address: string) =>
   `${address.slice(0, 8)}...${address.slice(-4)}`;
 
+type InputType = "email" | "number" | "text";
+
+/* Static for now, will be integrated directly into the question object itself for dynamic fields */
+const inputTypes = {
+  email: "email",
+  teamSize: "number",
+  profit2022: "number",
+  fundingSource: "text",
+} as {
+  [key: string]: InputType;
+};
+
 export interface SchemaQuestion {
   id: number;
   question: string;
-  type: "TEXT";
+  type: InputType;
   required: true;
   info: string;
   choices: [];
@@ -170,7 +182,7 @@ export const generateApplicationSchema = (
         schema.push({
           id: schema.length,
           question: camelToTitle(subKey),
-          type: "TEXT",
+          type: inputTypes[subKey],
           required: true,
           info: metadata[key][subKey],
           choices: [],
@@ -181,7 +193,7 @@ export const generateApplicationSchema = (
       schema.push({
         id: schema.length,
         question: camelToTitle(key),
-        type: "TEXT",
+        type: "text",
         required: true,
         info: metadata[key],
         choices: [],


### PR DESCRIPTION
application questions now have a non-stub input type associated with them. 

example ipfs hash: ipfs://bafkreig3e7wrfk7qptupqldckndlyq5kgwvgwmwn2knxkdrwsecuwtwjy4/

the possible types are now "text", "number", "email", and are hardcoded for the

##### Refers/Fixes

fixes #376 

##### Testing

tests fixed to reflect casing change in type field