### PR TITLE
fix: read project socials from project metadata

### DIFF
--- a/packages/round-manager/src/context/application/ApplicationContext.tsx
+++ b/packages/round-manager/src/context/application/ApplicationContext.tsx
@@ -41,7 +41,7 @@ const applicationReducer = (
     case ActionType.SET_APPLICATION:
       return {
         ...state,
-        applications: state.applications.concat(action.payload),
+        applications: [action.payload],
         getApplicationByIdError: undefined,
       };
     case ActionType.SET_ROUND_APPLICATIONS:
@@ -155,12 +155,8 @@ export const useApplicationById = (
 
   useEffect(() => {
     if (id) {
-      const existingApplication = context.state.applications.find(
-        (application) => application.id === id
-      );
-      if (!existingApplication) {
-        fetchApplicationById(context.dispatch, id, walletProvider);
-      }
+      // NB: we always refetch application by id to populate project owners for application page
+      fetchApplicationById(context.dispatch, id, walletProvider);
     }
   }, [id, walletProvider]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/round-manager/src/context/program/ReadProgramContext.tsx
+++ b/packages/round-manager/src/context/program/ReadProgramContext.tsx
@@ -15,7 +15,6 @@ enum ActionType {
   FINISH_LOADING = "FINISH_LOADING",
   SET_PROGRAMS = "SET_PROGRAMS",
   SET_ERROR_LIST_PROGRAMS = "SET_ERROR_LIST_PROGRAMS",
-  ADD_PROGRAM = "ADD_PROGRAM",
   SET_ERROR_GET_PROGRAM = "SET_ERROR_GET_PROGRAM",
 }
 
@@ -60,7 +59,7 @@ const fetchProgramsById = async (
   dispatch({ type: ActionType.SET_LOADING, payload: true });
   getProgramById(programId, walletProvider)
     .then((program) =>
-      dispatch({ type: ActionType.ADD_PROGRAM, payload: program })
+      dispatch({ type: ActionType.SET_PROGRAMS, payload: [program] })
     )
     .catch((error) =>
       dispatch({ type: ActionType.SET_ERROR_GET_PROGRAM, payload: error })
@@ -82,12 +81,6 @@ const programReducer = (state: ReadProgramState, action: Action) => {
       };
     case ActionType.SET_ERROR_LIST_PROGRAMS:
       return { ...state, programs: [], listProgramsError: action.payload };
-    case ActionType.ADD_PROGRAM:
-      return {
-        ...state,
-        programs: state.programs.concat(action.payload),
-        getProgramByIdError: undefined,
-      };
     case ActionType.SET_ERROR_GET_PROGRAM:
       return { ...state, getProgramByIdError: action.payload };
   }

--- a/packages/round-manager/src/features/api/types.ts
+++ b/packages/round-manager/src/features/api/types.ts
@@ -174,6 +174,8 @@ export type Project = {
   website: string;
   bannerImg?: string;
   logoImg?: string;
+  projectGithub?: string;
+  projectTwitter?: string;
   credentials: ProjectCredentials;
   metaPtr: MetadataPointer;
 };

--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -78,7 +78,7 @@ export default function ViewApplicationPage() {
 
   useEffect(() => {
     const applicationHasLoadedWithProjectOwners =
-      !isLoading && application && application.project?.owners;
+      !isLoading && application?.project?.owners;
     if (applicationHasLoadedWithProjectOwners) {
       const credentials: ProjectCredentials =
         application?.project!.credentials ?? {};

--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -9,7 +9,6 @@ import {
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useUpdateGrantApplicationMutation } from "../api/services/grantApplication";
-import { useListRoundsQuery } from "../api/services/round";
 import ConfirmationModal from "../common/ConfirmationModal";
 import Navbar from "../common/Navbar";
 import { useWallet } from "../common/Auth";
@@ -32,6 +31,7 @@ import AccessDenied from "../common/AccessDenied";
 import { useApplicationById } from "../../context/application/ApplicationContext";
 import { Spinner } from "../common/Spinner";
 import { ApplicationBanner, ApplicationLogo } from "./BulkApplicationCommon";
+import { useRoundById } from "../../context/RoundContext";
 
 type ApplicationStatus = "APPROVED" | "REJECTED";
 
@@ -42,9 +42,6 @@ enum VerifiedCredentialState {
 }
 
 enum ApplicationQuestions {
-  GITHUB = "Github",
-  GITHUB_ORGANIZATION = "Github Organization",
-  TWITTER = "Twitter",
   EMAIL = "Email",
   FUNDING_SOURCE = "Funding Source",
   PROFIT_2022 = "Profit2022",
@@ -53,6 +50,8 @@ enum ApplicationQuestions {
 
 export const IAM_SERVER =
   "did:key:z6MkghvGHLobLEdj1bgRLhS4LPGJAvbMA1tn2zcRyqmYU5LC";
+
+const verifier = new PassportVerifier();
 
 export default function ViewApplicationPage() {
   datadogLogs.logger.info("====> Route: /program/create");
@@ -73,48 +72,42 @@ export default function ViewApplicationPage() {
   const { chain, address, provider, signer } = useWallet();
 
   const navigate = useNavigate();
-  const verifier = new PassportVerifier();
 
   const { application, isLoading, getApplicationByIdError } =
     useApplicationById(id);
 
-  const credentials: ProjectCredentials =
-    application?.project!.credentials ?? {};
-
   useEffect(() => {
-    if (!credentials) {
-      return;
-    }
-    const verify = async () => {
-      const newVerifiedProviders: { [key: string]: VerifiedCredentialState } = {
-        ...verifiedProviders,
-      };
-      for (const provider of Object.keys(verifiedProviders)) {
-        const verifiableCredential = credentials[provider];
-        if (verifiableCredential) {
-          newVerifiedProviders[provider] = await isVerified(
-            verifiableCredential,
-            verifier,
-            provider,
-            application
-          );
-        }
+    const applicationHasLoadedWithProjectOwners =
+      !isLoading && application && application.project?.owners;
+    if (applicationHasLoadedWithProjectOwners) {
+      const credentials: ProjectCredentials =
+        application?.project!.credentials ?? {};
+
+      if (!credentials) {
+        return;
       }
+      const verify = async () => {
+        const newVerifiedProviders: { [key: string]: VerifiedCredentialState } =
+          { ...verifiedProviders };
+        for (const provider of Object.keys(verifiedProviders)) {
+          const verifiableCredential = credentials[provider];
+          if (verifiableCredential) {
+            newVerifiedProviders[provider] = await isVerified(
+              verifiableCredential,
+              verifier,
+              provider,
+              application
+            );
+          }
+        }
 
-      setVerifiedProviders(newVerifiedProviders);
-    };
-
-    verify();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const { round } = useListRoundsQuery(
-    { signerOrProvider: provider, roundId: roundId },
-    {
-      selectFromResult: ({ data }) => ({
-        round: data?.find((round) => round.id === roundId),
-      }),
+        setVerifiedProviders(newVerifiedProviders);
+      };
+      verify();
     }
-  );
+  }, [application, application?.project?.owners, isLoading]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const { round } = useRoundById(roundId);
 
   const [updateGrantApplication, { isLoading: updating }] =
     useUpdateGrantApplicationMutation();
@@ -367,7 +360,7 @@ export default function ViewApplicationPage() {
                     >
                       <TwitterIcon className="h-4 w-4 mr-2" />
                       <span className="text-sm text-violet-400 mr-2">
-                        {getAnswer(ApplicationQuestions.TWITTER)}
+                        {application?.project?.projectTwitter}
                       </span>
                       {getVerifiableCredentialVerificationResultView("twitter")}
                     </span>
@@ -378,7 +371,7 @@ export default function ViewApplicationPage() {
                     >
                       <GithubIcon className="h-4 w-4 mr-2" />
                       <span className="text-sm text-violet-400 mr-2">
-                        {getAnswer(ApplicationQuestions.GITHUB)}
+                        {application?.project?.projectGithub}
                       </span>
                       {getVerifiableCredentialVerificationResultView("github")}
                     </span>
@@ -419,16 +412,6 @@ export default function ViewApplicationPage() {
   );
 }
 
-const getCredentialSubject = (
-  question: string,
-  application: GrantApplication | undefined
-) => {
-  return (
-    application?.answers!.find((answer) => answer.question === question)
-      ?.answer || "N/A"
-  );
-};
-
 function vcProviderMatchesProject(
   provider: string,
   verifiableCredential: VerifiableCredential,
@@ -437,15 +420,14 @@ function vcProviderMatchesProject(
   let vcProviderMatchesProject = false;
   if (provider === "twitter") {
     vcProviderMatchesProject =
-      verifiableCredential.credentialSubject.provider?.split("#")[1] ===
-      getCredentialSubject(ApplicationQuestions.TWITTER, application);
+      verifiableCredential.credentialSubject.provider
+        ?.split("#")[1]
+        .toLowerCase() === application!.project!.projectTwitter?.toLowerCase();
   } else if (provider === "github") {
     vcProviderMatchesProject =
-      verifiableCredential.credentialSubject.provider?.split("#")[1] ===
-      getCredentialSubject(
-        ApplicationQuestions.GITHUB_ORGANIZATION,
-        application
-      );
+      verifiableCredential.credentialSubject.provider
+        ?.split("#")[1]
+        .toLowerCase() === application!.project!.projectGithub?.toLowerCase();
   }
   return vcProviderMatchesProject;
 }


### PR DESCRIPTION
##### Description

- verify credentials against project metadata instead of application answers
- verification should be case-insensitive
- always refetch application data to get project owners for verification
- use round context provider in application page instead of RTK Query


##### Refers/Fixes

fix #427
