### PR TITLE
fix(rm): use new application friendly labels when displaying answers

### DIFF
--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -32,6 +32,7 @@ import { useApplicationById } from "../../context/application/ApplicationContext
 import { Spinner } from "../common/Spinner";
 import { ApplicationBanner, ApplicationLogo } from "./BulkApplicationCommon";
 import { useRoundById } from "../../context/round/RoundContext";
+import { humanReadableLabels as ApplicationQuestions } from "../api/utils";
 
 type ApplicationStatus = "APPROVED" | "REJECTED";
 
@@ -39,13 +40,6 @@ enum VerifiedCredentialState {
   VALID,
   INVALID,
   PENDING,
-}
-
-enum ApplicationQuestions {
-  EMAIL = "Email",
-  FUNDING_SOURCE = "Funding Source",
-  PROFIT_2022 = "Profit2022",
-  TEAM_SIZE = "Team Size",
 }
 
 export const IAM_SERVER =
@@ -351,7 +345,7 @@ export default function ViewApplicationPage() {
                     <div className="text-grey-500 truncate block">
                       <MailIcon className="inline-flex h-4 w-4 text-grey-500 mr-1" />
                       <span className="text-xs text-grey-400">
-                        {getAnswer(ApplicationQuestions.EMAIL)}
+                        {getAnswer(ApplicationQuestions.email)}
                       </span>
                     </div>
                     <span
@@ -388,17 +382,17 @@ export default function ViewApplicationPage() {
 
                   <h2 className="text-xs mb-2">Funding Sources</h2>
                   <p className="text-base mb-6">
-                    {getAnswer(ApplicationQuestions.FUNDING_SOURCE)}
+                    {getAnswer(ApplicationQuestions.fundingSource)}
                   </p>
 
                   <h2 className="text-xs mb-2">Funding Profit</h2>
                   <p className="text-base mb-6">
-                    {getAnswer(ApplicationQuestions.PROFIT_2022)}
+                    {getAnswer(ApplicationQuestions.profit2022)}
                   </p>
 
                   <h2 className="text-xs mb-2">Team Size</h2>
                   <p className="text-base mb-6">
-                    {getAnswer(ApplicationQuestions.TEAM_SIZE)}
+                    {getAnswer(ApplicationQuestions.teamSize)}
                   </p>
                 </div>
                 <div className="sm:basis-1/4 text-center sm:ml-3"></div>

--- a/packages/round-manager/src/features/round/__tests__/ViewApplicationPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewApplicationPage.test.tsx
@@ -19,6 +19,7 @@ import { getApplicationById } from "../../api/application";
 import { faker } from "@faker-js/faker";
 import { RoundContext } from "../../../context/round/RoundContext";
 import { useWallet } from "../../common/Auth";
+import { humanReadableLabels } from "../../api/utils";
 
 jest.mock("../../api/services/grantApplication");
 jest.mock("../../api/application");
@@ -421,6 +422,37 @@ describe("ViewApplicationPage", () => {
     renderWithContext(<ViewApplicationPage />, { applications: [application] });
     expect(screen.getByText("Access Denied!")).toBeInTheDocument();
     expect(screen.queryByText("404 ERROR")).not.toBeInTheDocument();
+  });
+
+  it("should display project's application answers", async () => {
+    const expectedAnswers = Object.entries(humanReadableLabels).map(
+      ([_, questionLabel], index) => ({
+        questionId: index,
+        question: questionLabel,
+        answer: `My ${questionLabel} is ${faker.random.word()}`,
+      })
+    );
+
+    const grantApplicationWithApplicationAnswers = makeGrantApplicationData({
+      applicationIdOverride,
+      applicationAnswers: expectedAnswers,
+    });
+
+    (getApplicationById as any).mockResolvedValue(
+      grantApplicationWithApplicationAnswers
+    );
+    (useUpdateGrantApplicationMutation as any).mockReturnValue([
+      jest.fn(),
+      { isLoading: false },
+    ]);
+
+    renderWithContext(<ViewApplicationPage />, {
+      applications: [grantApplicationWithApplicationAnswers],
+    });
+
+    expect(
+      await screen.findByText(expectedAnswers[0].answer)
+    ).toBeInTheDocument();
   });
 });
 

--- a/packages/round-manager/src/test-utils.tsx
+++ b/packages/round-manager/src/test-utils.tsx
@@ -78,6 +78,7 @@ export interface MakeGrantApplicationDataParams {
   roundIdOverride?: string;
   projectGithubOverride?: string;
   projectTwitterOverride?: string;
+  applicationAnswers?: GrantApplication["answers"];
 }
 
 export const makeGrantApplicationData = (
@@ -89,6 +90,7 @@ export const makeGrantApplicationData = (
     roundIdOverride,
     projectGithubOverride,
     projectTwitterOverride,
+    applicationAnswers,
   } = {
     ownerAddress: faker.finance.ethereumAddress(),
     ...overrides,
@@ -136,6 +138,7 @@ export const makeGrantApplicationData = (
       projectTwitter: projectTwitterOverride ?? undefined,
       credentials: makeProjectCredentials(credentialInputData, ownerAddress),
     },
+    answers: applicationAnswers ?? [],
     projectsMetaPtr: {
       protocol: randomInt(1, 10),
       pointer: faker.random.alpha({ count: 59, casing: "lower" }),


### PR DESCRIPTION
##### Description
 
use new application friendly labels when displaying answers on application detail page

#430 updated the application schema to use human-friendly labels for the questions. However, the application detail page was hard-coded to the old labels. This change updates the application detail page to read application answers using the new labels.

NOTE -- this is currently not backward-compatible -- applications submitted with the "old" labels will not show correct answers on the application page anymore

##### Refers/Fixes

fix bug introduced in PR #452 (original story: #430)
