### PR TITLE
chore(githooks): make eslint fail on warnings to unify ci and local behaviour

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# treat warnings as errors to prevent the build passing locally, but failing on CI
+yarn lerna run --scope=round-manager lint:fix -- -- --max-warnings=0
 yarn run test

--- a/packages/round-manager/.eslintrc.js
+++ b/packages/round-manager/.eslintrc.js
@@ -20,6 +20,14 @@ module.exports = {
       rules: {
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            varsIgnorePattern: "_",
+            destructuredArrayIgnorePattern: "_",
+            argsIgnorePattern: "_",
+          },
+        ],
       },
     },
   ],

--- a/packages/round-manager/.eslintrc.js
+++ b/packages/round-manager/.eslintrc.js
@@ -23,9 +23,9 @@ module.exports = {
         "@typescript-eslint/no-unused-vars": [
           "warn",
           {
-            varsIgnorePattern: "_",
-            destructuredArrayIgnorePattern: "_",
-            argsIgnorePattern: "_",
+            varsIgnorePattern: "^_$",
+            destructuredArrayIgnorePattern: "^_$",
+            argsIgnorePattern: "^_$",
           },
         ],
       },

--- a/packages/round-manager/package.json
+++ b/packages/round-manager/package.json
@@ -102,7 +102,7 @@
     "tailwindcss": "^3.0.24"
   },
   "lint-staged": {
-    "*.{ts,tsx}": "eslint --cache --fix",
+    "*.{ts,tsx}": "yarn lint:fix",
     "*.{js,jsx,ts,tsx,md}": "prettier --write ."
   }
 }


### PR DESCRIPTION

ignore the eslint unused variable pattern if the variable name is exactly `_`

##### Refers/Fixes

Fixes #455