### PR TITLE
feat: show progress modal on bulk approve/reject 

### DIFF
--- a/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
+++ b/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
@@ -38,6 +38,7 @@ enum ActionType {
   SET_STORING_STATUS = "SET_STORING_STATUS",
   SET_CONTRACT_UPDATING_STATUS = "SET_CONTRACT_UPDATING_STATUS",
   SET_INDEXING_STATUS = "SET_INDEXING_STATUS",
+  RESET_TO_INITIAL_STATE = "RESET_TO_INITIAL_STATE",
 }
 
 interface Action {
@@ -88,6 +89,9 @@ const bulkUpdateGrantApplicationReducer = (
         ...state,
         indexingStatus: action.payload,
       };
+    case ActionType.RESET_TO_INITIAL_STATE: {
+      return initialBulkUpdateGrantApplicationState;
+    }
   }
   return state;
 };
@@ -104,6 +108,9 @@ async function _bulkUpdateGrantApplication({
   params,
 }: _bulkUpdateGrantApplicationParams) {
   const { roundId, applications } = params;
+  dispatch({
+    type: ActionType.RESET_TO_INITIAL_STATE,
+  });
   try {
     const newProjectsMetaPtr = await storeDocument({
       dispatch,

--- a/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
+++ b/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
@@ -124,7 +124,7 @@ async function _bulkUpdateGrantApplication({
   }
 }
 
-export const useBulkUpdateGrantApplication = () => {
+export const useBulkUpdateGrantApplications = () => {
   const context = useContext(BulkUpdateGrantApplicationContext);
 
   if (context === undefined) {
@@ -135,14 +135,18 @@ export const useBulkUpdateGrantApplication = () => {
 
   const { signer } = useWallet();
 
-  const bulkUpdateGrantApplication = (
+  const bulkUpdateGrantApplications = async (
     params: BulkUpdateGrantApplicationParams
   ) => {
-    _bulkUpdateGrantApplication({ dispatch: context.dispatch, signer, params });
+    return _bulkUpdateGrantApplication({
+      dispatch: context.dispatch,
+      signer,
+      params,
+    });
   };
 
   return {
-    bulkUpdateGrantApplication,
+    bulkUpdateGrantApplications,
     IPFSCurrentStatus: context.state.IPFSCurrentStatus,
     contractUpdatingStatus: context.state.contractUpdatingStatus,
     indexingStatus: context.state.indexingStatus,

--- a/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
+++ b/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
@@ -1,0 +1,268 @@
+import {
+  GrantApplication,
+  ProgressStatus,
+  Web3Instance,
+} from "../../features/api/types";
+import React, { createContext, useContext, useReducer } from "react";
+import {
+  updateApplicationList,
+  updateRoundContract,
+} from "../../features/api/application";
+// import { saveToIPFS } from "../../features/api/ipfs";
+import { datadogLogs } from "@datadog/browser-logs";
+import { waitForSubgraphSyncTo } from "../../features/api/subgraph";
+import { Signer } from "@ethersproject/abstract-signer";
+import { useWallet } from "../../features/common/Auth";
+
+export interface BulkUpdateGrantApplicationState {
+  IPFSCurrentStatus: ProgressStatus;
+  contractUpdatingStatus: ProgressStatus;
+  indexingStatus: ProgressStatus;
+}
+
+export type BulkUpdateGrantApplicationParams = {
+  roundId: string;
+  applications: GrantApplication[];
+};
+
+export const initialBulkUpdateGrantApplicationState: BulkUpdateGrantApplicationState =
+  {
+    IPFSCurrentStatus: ProgressStatus.NOT_STARTED,
+    contractUpdatingStatus: ProgressStatus.NOT_STARTED,
+    indexingStatus: ProgressStatus.NOT_STARTED,
+  };
+
+type Dispatch = (action: Action) => void;
+
+enum ActionType {
+  SET_STORING_STATUS = "SET_STORING_STATUS",
+  SET_CONTRACT_UPDATING_STATUS = "SET_CONTRACT_UPDATING_STATUS",
+  SET_INDEXING_STATUS = "SET_INDEXING_STATUS",
+}
+
+interface Action {
+  type: ActionType;
+  payload?: any;
+}
+
+export const BulkUpdateGrantApplicationContext = createContext<
+  { state: BulkUpdateGrantApplicationState; dispatch: Dispatch } | undefined
+>(undefined);
+
+export const BulkUpdateGrantApplicationProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [state, dispatch] = useReducer(
+    bulkUpdateGrantApplicationReducer,
+    initialBulkUpdateGrantApplicationState
+  );
+
+  const providerProps = {
+    state,
+    dispatch,
+  };
+
+  return (
+    <BulkUpdateGrantApplicationContext.Provider value={providerProps}>
+      {children}
+    </BulkUpdateGrantApplicationContext.Provider>
+  );
+};
+
+const bulkUpdateGrantApplicationReducer = (
+  state: BulkUpdateGrantApplicationState,
+  action: Action
+) => {
+  switch (action.type) {
+    case ActionType.SET_STORING_STATUS:
+      return { ...state, IPFSCurrentStatus: action.payload };
+    case ActionType.SET_CONTRACT_UPDATING_STATUS:
+      return {
+        ...state,
+        contractUpdatingStatus: action.payload,
+      };
+    case ActionType.SET_INDEXING_STATUS:
+      return {
+        ...state,
+        indexingStatus: action.payload,
+      };
+  }
+  return state;
+};
+
+interface _bulkUpdateGrantApplicationParams {
+  dispatch: Dispatch;
+  signer: Signer;
+  params: BulkUpdateGrantApplicationParams;
+}
+
+async function _bulkUpdateGrantApplication({
+  dispatch,
+  signer,
+  params,
+}: _bulkUpdateGrantApplicationParams) {
+  const { roundId, applications } = params;
+  try {
+    const newProjectsMetaPtr = await storeDocument({
+      dispatch,
+      signer,
+      roundId,
+      applications,
+    });
+    const transactionBlockNumber = await updateContract({
+      dispatch,
+      signer,
+      roundId,
+      newProjectsMetaPtr,
+    });
+    await waitForSubgraphToUpdate(dispatch, signer, transactionBlockNumber);
+  } catch (error) {
+    datadogLogs.logger.error(`error: _bulkUpdateGrantApplication - ${error}`);
+    console.error("Error while bulk updating applications: ", error);
+  }
+}
+
+export const useBulkUpdateGrantApplication = () => {
+  const context = useContext(BulkUpdateGrantApplicationContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useBulkUpdateGrantApplication must be used within a BulkUpdateGrantApplicationProvider"
+    );
+  }
+
+  const { signer } = useWallet();
+
+  const bulkUpdateGrantApplication = (
+    params: BulkUpdateGrantApplicationParams
+  ) => {
+    _bulkUpdateGrantApplication({ dispatch: context.dispatch, signer, params });
+  };
+
+  return {
+    bulkUpdateGrantApplication,
+    IPFSCurrentStatus: context.state.IPFSCurrentStatus,
+    contractUpdatingStatus: context.state.contractUpdatingStatus,
+    indexingStatus: context.state.indexingStatus,
+  };
+};
+
+interface StoreDocumentParams {
+  dispatch: Dispatch;
+  signer: Signer;
+  roundId: string;
+  applications: GrantApplication[];
+}
+
+const storeDocument = async ({
+  dispatch,
+  signer,
+  roundId,
+  applications,
+}: StoreDocumentParams): Promise<string> => {
+  try {
+    dispatch({
+      type: ActionType.SET_STORING_STATUS,
+      payload: ProgressStatus.IN_PROGRESS,
+    });
+    // TODO pass in correct data
+    // const ipfsHash = await saveToIPFS({});
+    const chainId = await signer.getChainId();
+    const ipfsHash = await updateApplicationList(
+      applications,
+      roundId,
+      chainId
+    );
+    dispatch({
+      type: ActionType.SET_STORING_STATUS,
+      payload: ProgressStatus.IS_SUCCESS,
+    });
+
+    return ipfsHash;
+  } catch (error) {
+    datadogLogs.logger.error(`error: storeDocument - ${error}`);
+    dispatch({
+      type: ActionType.SET_STORING_STATUS,
+      payload: ProgressStatus.IS_ERROR,
+    });
+    throw error;
+  }
+};
+
+interface UpdateContractParams {
+  dispatch: Dispatch;
+  signer: Signer;
+  roundId: string;
+  newProjectsMetaPtr: string;
+}
+
+const updateContract = async ({
+  dispatch,
+  signer,
+  roundId,
+  newProjectsMetaPtr,
+}: UpdateContractParams): Promise<number> => {
+  try {
+    dispatch({
+      type: ActionType.SET_CONTRACT_UPDATING_STATUS,
+      payload: ProgressStatus.IN_PROGRESS,
+    });
+
+    const { transactionBlockNumber } = await updateRoundContract(
+      roundId,
+      signer,
+      newProjectsMetaPtr
+    );
+
+    dispatch({
+      type: ActionType.SET_CONTRACT_UPDATING_STATUS,
+      payload: ProgressStatus.IS_SUCCESS,
+    });
+
+    return transactionBlockNumber;
+  } catch (error) {
+    datadogLogs.logger.error(`error: updateContract - ${error}`);
+    dispatch({
+      type: ActionType.SET_CONTRACT_UPDATING_STATUS,
+      payload: ProgressStatus.IS_ERROR,
+    });
+    throw error;
+  }
+};
+
+async function waitForSubgraphToUpdate(
+  dispatch: (action: Action) => void,
+  signerOrProvider: Web3Instance["provider"],
+  transactionBlockNumber: number
+) {
+  try {
+    datadogLogs.logger.error(
+      `waitForSubgraphToUpdate: txnBlockNumber - ${transactionBlockNumber}`
+    );
+
+    dispatch({
+      type: ActionType.SET_INDEXING_STATUS,
+      payload: ProgressStatus.IN_PROGRESS,
+    });
+
+    const chainId = await signerOrProvider.getChainId();
+
+    await waitForSubgraphSyncTo(chainId, transactionBlockNumber);
+
+    dispatch({
+      type: ActionType.SET_INDEXING_STATUS,
+      payload: ProgressStatus.IS_SUCCESS,
+    });
+  } catch (error) {
+    datadogLogs.logger.error(
+      `error: waitForSubgraphToUpdate - ${error}. Data - ${transactionBlockNumber}`
+    );
+    dispatch({
+      type: ActionType.SET_INDEXING_STATUS,
+      payload: ProgressStatus.IS_ERROR,
+    });
+    throw error;
+  }
+}

--- a/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
+++ b/packages/round-manager/src/context/application/BulkUpdateGrantApplicationContext.tsx
@@ -8,7 +8,6 @@ import {
   updateApplicationList,
   updateRoundContract,
 } from "../../features/api/application";
-// import { saveToIPFS } from "../../features/api/ipfs";
 import { datadogLogs } from "@datadog/browser-logs";
 import { waitForSubgraphSyncTo } from "../../features/api/subgraph";
 import { Signer } from "@ethersproject/abstract-signer";
@@ -178,8 +177,6 @@ const storeDocument = async ({
       type: ActionType.SET_STORING_STATUS,
       payload: ProgressStatus.IN_PROGRESS,
     });
-    // TODO pass in correct data
-    // const ipfsHash = await saveToIPFS({});
     const chainId = await signer.getChainId();
     const ipfsHash = await updateApplicationList(
       applications,

--- a/packages/round-manager/src/context/application/__tests__/BulkUpdateGrantApplicationContext.test.tsx
+++ b/packages/round-manager/src/context/application/__tests__/BulkUpdateGrantApplicationContext.test.tsx
@@ -1,0 +1,237 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ProgressStatus } from "../../../features/api/types";
+import {
+  BulkUpdateGrantApplicationParams,
+  BulkUpdateGrantApplicationProvider,
+  useBulkUpdateGrantApplication,
+} from "../BulkUpdateGrantApplicationContext";
+// import { saveToIPFS } from "../../../features/api/ipfs";
+import {
+  updateRoundContract,
+  updateApplicationList,
+} from "../../../features/api/application";
+import { waitForSubgraphSyncTo } from "../../../features/api/subgraph";
+
+// jest.mock("../../../features/api/ipfs");
+jest.mock("../../../features/api/application");
+jest.mock("../../../features/api/subgraph");
+jest.mock("../../../features/common/Auth", () => ({
+  useWallet: () => mockWallet,
+}));
+const mockWallet = {
+  address: "0x0",
+  signer: {
+    getChainId: () => {},
+  },
+};
+
+describe("<BulkUpdateGrantApplicationProvider />", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("useBulkUpdateGrantApplication", () => {
+    it("sets ipfs status to in progress when saving to ipfs", async () => {
+      (updateApplicationList as jest.Mock).mockReturnValue(
+        new Promise<any>(() => {})
+      );
+      renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+      fireEvent.click(screen.getByTestId("update-grant-application"));
+
+      expect(
+        await screen.findByTestId(
+          `storing-status-is-${ProgressStatus.IN_PROGRESS}`
+        )
+      );
+    });
+
+    it("sets ipfs status to complete when saving to ipfs succeeds", async () => {
+      (updateApplicationList as jest.Mock).mockResolvedValue("some hash");
+      (updateRoundContract as jest.Mock).mockReturnValue(
+        new Promise<any>(() => {})
+      );
+      renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+      fireEvent.click(screen.getByTestId("update-grant-application"));
+
+      expect(
+        await screen.findByTestId(
+          `storing-status-is-${ProgressStatus.IS_SUCCESS}`
+        )
+      );
+    });
+
+    it("sets contract update status to in progress when contract is being updated", async () => {
+      (updateApplicationList as jest.Mock).mockResolvedValue("some hash");
+      (updateRoundContract as jest.Mock).mockReturnValue(
+        new Promise<any>(() => {})
+      );
+
+      renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+      fireEvent.click(screen.getByTestId("update-grant-application"));
+
+      expect(
+        await screen.findByTestId(
+          `contract-updating-status-is-${ProgressStatus.IN_PROGRESS}`
+        )
+      );
+    });
+
+    it("sets update status to complete when updating contract succeeds", async () => {
+      (updateApplicationList as jest.Mock).mockResolvedValue("some hash");
+      (updateRoundContract as jest.Mock).mockResolvedValue({
+        transactionBlockNumber: 100,
+      });
+      renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+      fireEvent.click(screen.getByTestId("update-grant-application"));
+
+      expect(
+        await screen.findByTestId(
+          `contract-updating-status-is-${ProgressStatus.IS_SUCCESS}`
+        )
+      );
+    });
+
+    it("sets indexing status to in progress when waiting for subgraph to index", async () => {
+      const transactionBlockNumber = 10;
+      (updateApplicationList as jest.Mock).mockResolvedValue("bafabcdef");
+      (updateRoundContract as jest.Mock).mockResolvedValue({
+        transactionBlockNumber,
+      });
+      (waitForSubgraphSyncTo as jest.Mock).mockReturnValue(
+        new Promise<any>(() => {})
+      );
+
+      renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+      const createContract = screen.getByTestId("update-grant-application");
+      fireEvent.click(createContract);
+
+      expect(
+        await screen.findByTestId(
+          `indexing-status-is-${ProgressStatus.IN_PROGRESS}`
+        )
+      );
+    });
+
+    it("sets indexing status to completed when subgraph is finished indexing", async () => {
+      const transactionBlockNumber = 10;
+      (updateApplicationList as jest.Mock).mockResolvedValue("bafabcdef");
+      (updateRoundContract as jest.Mock).mockResolvedValue({
+        transactionBlockNumber,
+      });
+      (waitForSubgraphSyncTo as jest.Mock).mockResolvedValue({});
+
+      renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+      const createContract = screen.getByTestId("update-grant-application");
+      fireEvent.click(createContract);
+
+      expect(
+        await screen.findByTestId(
+          `indexing-status-is-${ProgressStatus.IS_SUCCESS}`
+        )
+      );
+    });
+
+    describe("useBulkUpdateGrantApplication Errors", () => {
+      let consoleErrorSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        consoleErrorSpy = jest
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        consoleErrorSpy.mockClear();
+      });
+
+      it("sets ipfs status to error when ipfs save fails", async () => {
+        (updateApplicationList as jest.Mock).mockRejectedValue(new Error(":("));
+
+        renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+        fireEvent.click(screen.getByTestId("update-grant-application"));
+
+        expect(
+          await screen.findByTestId(
+            `storing-status-is-${ProgressStatus.IS_ERROR}`
+          )
+        ).toBeInTheDocument();
+      });
+
+      it("sets contract updating status to error when updating contract fails", async () => {
+        (updateRoundContract as jest.Mock).mockRejectedValue(new Error(":("));
+
+        renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+
+        fireEvent.click(screen.getByTestId("update-grant-application"));
+
+        expect(
+          await screen.findByTestId(
+            `contract-updating-status-is-${ProgressStatus.IS_ERROR}`
+          )
+        ).toBeInTheDocument();
+      });
+
+      it("sets indexing status to error when waiting for subgraph to sync fails", async () => {
+        (updateApplicationList as jest.Mock).mockResolvedValue("asdf");
+        (updateRoundContract as jest.Mock).mockResolvedValue({
+          transactionBlockNumber: 100,
+        });
+        (waitForSubgraphSyncTo as jest.Mock).mockRejectedValue(new Error(":("));
+
+        renderWithProvider(<TestUseBulkUpdateGrantApplicationComponent />);
+        fireEvent.click(screen.getByTestId("update-grant-application"));
+
+        expect(
+          await screen.findByTestId(
+            `indexing-status-is-${ProgressStatus.IS_ERROR}`
+          )
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});
+
+const TestUseBulkUpdateGrantApplicationComponent = () => {
+  const {
+    bulkUpdateGrantApplication,
+    IPFSCurrentStatus,
+    contractUpdatingStatus,
+    indexingStatus,
+  } = useBulkUpdateGrantApplication();
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          bulkUpdateGrantApplication({} as BulkUpdateGrantApplicationParams);
+        }}
+        data-testid="update-grant-application"
+      >
+        Bulk Update Grant Applications
+      </button>
+
+      <div data-testid={`storing-status-is-${IPFSCurrentStatus}`} />
+
+      <div
+        data-testid={`contract-updating-status-is-${contractUpdatingStatus}`}
+      />
+
+      <div data-testid={`indexing-status-is-${indexingStatus}`} />
+    </div>
+  );
+};
+
+function renderWithProvider(ui: JSX.Element) {
+  render(
+    <BulkUpdateGrantApplicationProvider>
+      {ui}
+    </BulkUpdateGrantApplicationProvider>
+  );
+}

--- a/packages/round-manager/src/context/application/__tests__/BulkUpdateGrantApplicationContext.test.tsx
+++ b/packages/round-manager/src/context/application/__tests__/BulkUpdateGrantApplicationContext.test.tsx
@@ -3,7 +3,7 @@ import { ProgressStatus } from "../../../features/api/types";
 import {
   BulkUpdateGrantApplicationParams,
   BulkUpdateGrantApplicationProvider,
-  useBulkUpdateGrantApplication,
+  useBulkUpdateGrantApplications,
 } from "../BulkUpdateGrantApplicationContext";
 // import { saveToIPFS } from "../../../features/api/ipfs";
 import {
@@ -200,17 +200,17 @@ describe("<BulkUpdateGrantApplicationProvider />", () => {
 
 const TestUseBulkUpdateGrantApplicationComponent = () => {
   const {
-    bulkUpdateGrantApplication,
+    bulkUpdateGrantApplications,
     IPFSCurrentStatus,
     contractUpdatingStatus,
     indexingStatus,
-  } = useBulkUpdateGrantApplication();
+  } = useBulkUpdateGrantApplications();
 
   return (
     <div>
       <button
         onClick={() => {
-          bulkUpdateGrantApplication({} as BulkUpdateGrantApplicationParams);
+          bulkUpdateGrantApplications({} as BulkUpdateGrantApplicationParams);
         }}
         data-testid="update-grant-application"
       >

--- a/packages/round-manager/src/context/program/CreateProgramContext.tsx
+++ b/packages/round-manager/src/context/program/CreateProgramContext.tsx
@@ -30,6 +30,7 @@ enum ActionType {
   SET_STORING_STATUS = "SET_STORING_STATUS",
   SET_DEPLOYMENT_STATUS = "SET_DEPLOYMENT_STATUS",
   SET_INDEXING_STATUS = "SET_INDEXING_STATUS",
+  RESET_TO_INITIAL_STATE = "RESET_TO_INITIAL_STATE",
 }
 
 export const initialCreateProgramState: CreateProgramState = {
@@ -56,6 +57,9 @@ const createProgramReducer = (state: CreateProgramState, action: Action) => {
         ...state,
         indexingStatus: action.payload.indexingStatus,
       };
+    case ActionType.RESET_TO_INITIAL_STATE: {
+      return initialCreateProgramState;
+    }
   }
   return state;
 };
@@ -88,6 +92,9 @@ const _createProgram = async ({
   operatorWallets,
   signerOrProvider,
 }: _createProgramParams) => {
+  dispatch({
+    type: ActionType.RESET_TO_INITIAL_STATE,
+  });
   try {
     const IpfsHash = await storeDocument(dispatch, programName);
 
@@ -121,7 +128,7 @@ export const useCreateProgram = () => {
   const { signer: walletSigner } = useWallet();
 
   const createProgram = (programName: string, operatorWallets: string[]) => {
-    _createProgram({
+    return _createProgram({
       dispatch: context.dispatch,
       programName: programName,
       operatorWallets,

--- a/packages/round-manager/src/context/program/__tests__/CreateProgramContext.test.tsx
+++ b/packages/round-manager/src/context/program/__tests__/CreateProgramContext.test.tsx
@@ -201,7 +201,6 @@ describe("<CreateProgramProvider />", () => {
       (deployProgramContract as jest.Mock).mockResolvedValue({
         transactionBlockNumber: 100,
       });
-
       (waitForSubgraphSyncTo as jest.Mock).mockRejectedValue(new Error(":("));
 
       renderWithProvider(<TestUseCreateProgramComponent />);
@@ -213,6 +212,69 @@ describe("<CreateProgramProvider />", () => {
           `indexing-status-is-${ProgressStatus.IS_ERROR}`
         )
       ).toBeInTheDocument();
+    });
+
+    it("if ipfs save fails, resets ipfs status when create round is retried", async () => {
+      (saveToIPFS as jest.Mock)
+        .mockRejectedValueOnce(new Error(":("))
+        .mockReturnValue(new Promise<any>(() => {}));
+
+      renderWithProvider(<TestUseCreateProgramComponent />);
+      fireEvent.click(screen.getByTestId("create-program"));
+
+      await screen.findByTestId(`storing-status-is-${ProgressStatus.IS_ERROR}`);
+
+      // retry create-program operation
+      fireEvent.click(screen.getByTestId("create-program"));
+
+      expect(
+        screen.queryByTestId(`storing-status-is-${ProgressStatus.IS_ERROR}`)
+      ).not.toBeInTheDocument();
+    });
+
+    it("if contract deployment fails, resets contract deployment status when create round is retried", async () => {
+      (saveToIPFS as jest.Mock).mockResolvedValue("asdf");
+      (deployProgramContract as jest.Mock).mockResolvedValue({
+        transactionBlockNumber: 100,
+      });
+      (waitForSubgraphSyncTo as jest.Mock)
+        .mockRejectedValueOnce(new Error(":("))
+        .mockReturnValue(new Promise<any>(() => {}));
+
+      renderWithProvider(<TestUseCreateProgramComponent />);
+      fireEvent.click(screen.getByTestId("create-program"));
+
+      await screen.findByTestId(
+        `indexing-status-is-${ProgressStatus.IS_ERROR}`
+      );
+
+      // retry create-program operation
+      fireEvent.click(screen.getByTestId("create-program"));
+
+      expect(
+        screen.queryByTestId(`indexing-status-is-${ProgressStatus.IS_ERROR}`)
+      ).not.toBeInTheDocument();
+    });
+
+    it("if indexing fails, resets indexing status when create round is retried", async () => {
+      (saveToIPFS as jest.Mock).mockResolvedValue("asdf");
+      (deployProgramContract as jest.Mock)
+        .mockRejectedValueOnce(new Error(":("))
+        .mockReturnValue(new Promise<any>(() => {}));
+
+      renderWithProvider(<TestUseCreateProgramComponent />);
+      fireEvent.click(screen.getByTestId("create-program"));
+
+      await screen.findByTestId(
+        `deploying-status-is-${ProgressStatus.IS_ERROR}`
+      );
+
+      // retry create-program operation
+      fireEvent.click(screen.getByTestId("create-program"));
+
+      expect(
+        screen.queryByTestId(`deploying-status-is-${ProgressStatus.IS_ERROR}`)
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/round-manager/src/context/round/CreateRoundContext.tsx
+++ b/packages/round-manager/src/context/round/CreateRoundContext.tsx
@@ -48,6 +48,7 @@ enum ActionType {
   SET_STORING_STATUS = "SET_STORING_STATUS",
   SET_DEPLOYMENT_STATUS = "SET_DEPLOYMENT_STATUS",
   SET_INDEXING_STATUS = "SET_INDEXING_STATUS",
+  RESET_TO_INITIAL_STATE = "RESET_TO_INITIAL_STATE",
 }
 
 const createRoundReducer = (state: CreateRoundState, action: Action) => {
@@ -64,6 +65,9 @@ const createRoundReducer = (state: CreateRoundState, action: Action) => {
         ...state,
         indexingStatus: action.payload.indexingStatus,
       };
+    case ActionType.RESET_TO_INITIAL_STATE: {
+      return initialCreateRoundState;
+    }
   }
   return state;
 };
@@ -105,6 +109,9 @@ const _createRound = async ({
     applicationQuestions,
     round,
   } = createRoundData;
+  dispatch({
+    type: ActionType.RESET_TO_INITIAL_STATE,
+  });
   try {
     datadogLogs.logger.info(`_createRound: ${round}`);
 
@@ -156,7 +163,7 @@ export const useCreateRound = () => {
   const { signer: walletSigner } = useWallet();
 
   const createRound = (createRoundData: CreateRoundData) => {
-    _createRound({
+    return _createRound({
       dispatch: context.dispatch,
       signerOrProvider: walletSigner,
       createRoundData,

--- a/packages/round-manager/src/context/round/__tests__/CreateRoundContext.test.tsx
+++ b/packages/round-manager/src/context/round/__tests__/CreateRoundContext.test.tsx
@@ -213,6 +213,69 @@ describe("<CreateRoundProvider />", () => {
         )
       ).toBeInTheDocument();
     });
+
+    it("if ipfs save fails, resets ipfs status when create round is retried", async () => {
+      (saveToIPFS as jest.Mock)
+        .mockRejectedValueOnce(new Error(":("))
+        .mockReturnValue(new Promise<any>(() => {}));
+
+      renderWithProvider(<TestUseCreateRoundComponent />);
+      fireEvent.click(screen.getByTestId("create-round"));
+
+      await screen.findByTestId(`storing-status-is-${ProgressStatus.IS_ERROR}`);
+
+      // retry create-round operation
+      fireEvent.click(screen.getByTestId("create-round"));
+
+      expect(
+        screen.queryByTestId(`storing-status-is-${ProgressStatus.IS_ERROR}`)
+      ).not.toBeInTheDocument();
+    });
+
+    it("if contract deployment fails, resets contract deployment status when create round is retried", async () => {
+      (saveToIPFS as jest.Mock).mockResolvedValue("asdf");
+      (deployRoundContract as jest.Mock)
+        .mockRejectedValueOnce(new Error(":("))
+        .mockReturnValue(new Promise<any>(() => {}));
+
+      renderWithProvider(<TestUseCreateRoundComponent />);
+      fireEvent.click(screen.getByTestId("create-round"));
+
+      await screen.findByTestId(
+        `deploying-status-is-${ProgressStatus.IS_ERROR}`
+      );
+
+      // retry create-round operation
+      fireEvent.click(screen.getByTestId("create-round"));
+
+      expect(
+        screen.queryByTestId(`deploying-status-is-${ProgressStatus.IS_ERROR}`)
+      ).not.toBeInTheDocument();
+    });
+
+    it("if indexing fails, resets indexing status when create round is retried", async () => {
+      (saveToIPFS as jest.Mock).mockResolvedValue("asdf");
+      (deployRoundContract as jest.Mock).mockResolvedValue({
+        transactionBlockNumber: 100,
+      });
+      (waitForSubgraphSyncTo as jest.Mock)
+        .mockRejectedValueOnce(new Error(":("))
+        .mockReturnValue(new Promise<any>(() => {}));
+
+      renderWithProvider(<TestUseCreateRoundComponent />);
+      fireEvent.click(screen.getByTestId("create-round"));
+
+      await screen.findByTestId(
+        `indexing-status-is-${ProgressStatus.IS_ERROR}`
+      );
+
+      // retry create-round operation
+      fireEvent.click(screen.getByTestId("create-round"));
+
+      expect(
+        screen.queryByTestId(`indexing-status-is-${ProgressStatus.IS_ERROR}`)
+      ).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -83,7 +83,7 @@ export default function CreateProgram() {
   const onSubmit: SubmitHandler<FormData> = async (data) => {
     try {
       setOpenProgressModal(true);
-      createProgram(
+      await createProgram(
         data.name,
         data.operators.map((op) => op.wallet)
       );

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -1,6 +1,4 @@
 import { Link, useParams } from "react-router-dom";
-
-import { useBulkUpdateGrantApplicationsMutation } from "../api/services/grantApplication";
 import { useWallet } from "../common/Auth";
 import { Spinner } from "../common/Spinner";
 import {
@@ -14,6 +12,7 @@ import {
 import {
   ApplicationStatus,
   GrantApplication,
+  ProgressStatus,
   ProjectStatus,
 } from "../api/types";
 import { useEffect, useState } from "react";
@@ -28,10 +27,12 @@ import {
 } from "./BulkApplicationCommon";
 import { useApplicationByRoundId } from "../../context/application/ApplicationContext";
 import { datadogLogs } from "@datadog/browser-logs";
+import { useBulkUpdateGrantApplications } from "../../context/application/BulkUpdateGrantApplicationContext";
+import ProgressModal from "../common/ProgressModal";
 
 export default function ApplicationsApproved() {
   const { id } = useParams();
-  const { provider, signer } = useWallet();
+  const { chain } = useWallet();
 
   const { applications, isLoading } = useApplicationByRoundId(id!);
   const approvedApplications =
@@ -41,10 +42,46 @@ export default function ApplicationsApproved() {
     ) || [];
 
   const [bulkSelectApproved, setBulkSelectApproved] = useState(false);
-  const [openModal, setOpenModal] = useState(false);
+  const [openConfirmationModal, setOpenConfirmationModal] = useState(false);
+  const [openProgressModal, setOpenProgressModal] = useState(false);
   const [selected, setSelected] = useState<GrantApplication[]>([]);
-  const [bulkUpdateGrantApplications, { isLoading: isBulkUpdateLoading }] =
-    useBulkUpdateGrantApplicationsMutation();
+
+  const {
+    bulkUpdateGrantApplications,
+    IPFSCurrentStatus,
+    contractUpdatingStatus,
+    indexingStatus,
+  } = useBulkUpdateGrantApplications();
+  const isBulkUpdateLoading =
+    IPFSCurrentStatus == ProgressStatus.IN_PROGRESS ||
+    contractUpdatingStatus == ProgressStatus.IN_PROGRESS ||
+    indexingStatus == ProgressStatus.IN_PROGRESS;
+
+  const progressSteps: any = [
+    {
+      name: "Storing",
+      description: "The metadata is being saved in a safe place.",
+      status: IPFSCurrentStatus,
+    },
+    {
+      name: "Updating",
+      description: `Connecting to the ${chain.name} blockchain.`,
+      status: contractUpdatingStatus,
+    },
+    {
+      name: "Indexing",
+      description: "The subgraph is indexing the data.",
+      status: indexingStatus,
+    },
+    {
+      name: "Redirecting",
+      description: "Just another moment while we finish things up.",
+      status:
+        indexingStatus === ProgressStatus.IS_SUCCESS
+          ? ProgressStatus.IN_PROGRESS
+          : ProgressStatus.NOT_STARTED,
+    },
+  ];
 
   useEffect(() => {
     if (!isLoading || !bulkSelectApproved) {
@@ -83,16 +120,17 @@ export default function ApplicationsApproved() {
 
   const handleBulkReview = async () => {
     try {
+      setOpenProgressModal(true);
+      setOpenConfirmationModal(false);
       await bulkUpdateGrantApplications({
         roundId: id!,
         applications: selected.filter(
           (application) => application.status === "REJECTED"
         ),
-        signer,
-        provider,
-      }).unwrap();
+      });
       setBulkSelectApproved(false);
-      setOpenModal(false);
+      setOpenProgressModal(false);
+      window.location.reload();
     } catch (error) {
       datadogLogs.logger.error(`error: handleBulkReview - ${error}, id: ${id}`);
       console.error(error);
@@ -149,7 +187,7 @@ export default function ApplicationsApproved() {
           <Continue
             grantApplications={selected}
             status="REJECTED"
-            onClick={() => setOpenModal(true)}
+            onClick={() => setOpenConfirmationModal(true)}
           />
         )}
       <ConfirmationModal
@@ -167,8 +205,14 @@ export default function ApplicationsApproved() {
             <AdditionalGasFeesNote />
           </>
         }
-        isOpen={openModal}
-        setIsOpen={setOpenModal}
+        isOpen={openConfirmationModal}
+        setIsOpen={setOpenConfirmationModal}
+      />
+      <ProgressModal
+        isOpen={openProgressModal}
+        setIsOpen={setOpenProgressModal}
+        subheading={"Please hold while we update the grant applications."}
+        steps={progressSteps}
       />
     </>
   );

--- a/packages/round-manager/src/features/round/ApplicationsRejected.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsRejected.tsx
@@ -2,11 +2,10 @@ import { datadogLogs } from "@datadog/browser-logs";
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useApplicationByRoundId } from "../../context/application/ApplicationContext";
-
-import { useBulkUpdateGrantApplicationsMutation } from "../api/services/grantApplication";
 import {
   ApplicationStatus,
   GrantApplication,
+  ProgressStatus,
   ProjectStatus,
 } from "../api/types";
 import { useWallet } from "../common/Auth";
@@ -28,10 +27,12 @@ import {
   Continue,
   Select,
 } from "./BulkApplicationCommon";
+import { useBulkUpdateGrantApplications } from "../../context/application/BulkUpdateGrantApplicationContext";
+import ProgressModal from "../common/ProgressModal";
 
 export default function ApplicationsRejected() {
   const { id } = useParams();
-  const { provider, signer } = useWallet();
+  const { chain } = useWallet();
 
   const { applications, isLoading } = useApplicationByRoundId(id!);
   const rejectedApplications =
@@ -40,11 +41,46 @@ export default function ApplicationsRejected() {
     ) || [];
 
   const [bulkSelectRejected, setBulkSelectRejected] = useState(false);
-  const [openModal, setOpenModal] = useState(false);
+  const [openConfirmationModal, setOpenConfirmationModal] = useState(false);
+  const [openProgressModal, setOpenProgressModal] = useState(false);
   const [selected, setSelected] = useState<GrantApplication[]>([]);
 
-  const [bulkUpdateGrantApplications, { isLoading: isBulkUpdateLoading }] =
-    useBulkUpdateGrantApplicationsMutation();
+  const {
+    bulkUpdateGrantApplications,
+    IPFSCurrentStatus,
+    contractUpdatingStatus,
+    indexingStatus,
+  } = useBulkUpdateGrantApplications();
+  const isBulkUpdateLoading =
+    IPFSCurrentStatus == ProgressStatus.IN_PROGRESS ||
+    contractUpdatingStatus == ProgressStatus.IN_PROGRESS ||
+    indexingStatus == ProgressStatus.IN_PROGRESS;
+
+  const progressSteps: any = [
+    {
+      name: "Storing",
+      description: "The metadata is being saved in a safe place.",
+      status: IPFSCurrentStatus,
+    },
+    {
+      name: "Updating",
+      description: `Connecting to the ${chain.name} blockchain.`,
+      status: contractUpdatingStatus,
+    },
+    {
+      name: "Indexing",
+      description: "The subgraph is indexing the data.",
+      status: indexingStatus,
+    },
+    {
+      name: "Redirecting",
+      description: "Just another moment while we finish things up.",
+      status:
+        indexingStatus === ProgressStatus.IS_SUCCESS
+          ? ProgressStatus.IN_PROGRESS
+          : ProgressStatus.NOT_STARTED,
+    },
+  ];
 
   useEffect(() => {
     if (!isLoading || !bulkSelectRejected) {
@@ -83,16 +119,17 @@ export default function ApplicationsRejected() {
 
   const handleBulkReview = async () => {
     try {
+      setOpenProgressModal(true);
+      setOpenConfirmationModal(false);
       await bulkUpdateGrantApplications({
         roundId: id!,
         applications: selected.filter(
           (application) => application.status === "APPROVED"
         ),
-        signer,
-        provider,
-      }).unwrap();
+      });
       setBulkSelectRejected(false);
-      setOpenModal(false);
+      setOpenProgressModal(false);
+      window.location.reload();
     } catch (error) {
       datadogLogs.logger.error(`error: handleBulkReview - ${error}, id: ${id}`);
       console.error(error);
@@ -152,7 +189,7 @@ export default function ApplicationsRejected() {
           <Continue
             grantApplications={selected}
             status="APPROVED"
-            onClick={() => setOpenModal(true)}
+            onClick={() => setOpenConfirmationModal(true)}
           />
         )}
       <ConfirmationModal
@@ -170,8 +207,14 @@ export default function ApplicationsRejected() {
             <AdditionalGasFeesNote />
           </>
         }
-        isOpen={openModal}
-        setIsOpen={setOpenModal}
+        isOpen={openConfirmationModal}
+        setIsOpen={setOpenConfirmationModal}
+      />
+      <ProgressModal
+        isOpen={openProgressModal}
+        setIsOpen={setOpenProgressModal}
+        subheading={"Please hold while we update the grant applications."}
+        steps={progressSteps}
       />
     </>
   );

--- a/packages/round-manager/src/index.tsx
+++ b/packages/round-manager/src/index.tsx
@@ -29,6 +29,7 @@ import { ApplicationProvider } from "./context/application/ApplicationContext";
 import { CreateProgramProvider } from "./context/program/CreateProgramContext";
 import { RoundProvider } from "./context/round/RoundContext";
 import { CreateRoundProvider } from "./context/round/CreateRoundContext";
+import { BulkUpdateGrantApplicationProvider } from "./context/application/BulkUpdateGrantApplicationContext";
 
 // Initialize datadog
 initDatadog();
@@ -72,7 +73,9 @@ root.render(
                   element={
                     <RoundProvider>
                       <ApplicationProvider>
-                        <ViewRoundPage />
+                        <BulkUpdateGrantApplicationProvider>
+                          <ViewRoundPage />
+                        </BulkUpdateGrantApplicationProvider>
                       </ApplicationProvider>
                     </RoundProvider>
                   }

--- a/packages/round-manager/src/test-utils.tsx
+++ b/packages/round-manager/src/test-utils.tsx
@@ -29,6 +29,11 @@ import {
   ApplicationState,
   initialApplicationState,
 } from "./context/application/ApplicationContext";
+import {
+  BulkUpdateGrantApplicationContext,
+  BulkUpdateGrantApplicationState,
+  initialBulkUpdateGrantApplicationState,
+} from "./context/application/BulkUpdateGrantApplicationContext";
 
 export const makeProgramData = (overrides: Partial<Program> = {}): Program => ({
   id: faker.finance.ethereumAddress(),
@@ -284,6 +289,25 @@ export const wrapWithRoundContext = (
   >
     {ui}
   </RoundContext.Provider>
+);
+
+export const wrapWithBulkUpdateGrantApplicationContext = (
+  ui: JSX.Element,
+  bulkUpdateOverrides: Partial<BulkUpdateGrantApplicationState> = {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dispatch: any = jest.fn()
+) => (
+  <BulkUpdateGrantApplicationContext.Provider
+    value={{
+      state: {
+        ...initialBulkUpdateGrantApplicationState,
+        ...bulkUpdateOverrides,
+      },
+      dispatch,
+    }}
+  >
+    {ui}
+  </BulkUpdateGrantApplicationContext.Provider>
 );
 
 type ContextMock<T> = {


### PR DESCRIPTION
##### Description

- create BulkUpdateGrantApplicationContext 
- use new useBulkUpdateGrantApplications in ApplicationsReceived, ApplicationsApproved, Applications Rejected
- clear error statuses when create or update operations are retried
- show progress modal on bulk approve/reject 

##### Refers/Fixes

fix #400 
