### PR TITLE
fix: nest error modal inside progress modal to prevent scroll locking

### DIFF
--- a/packages/round-manager/src/features/common/ErrorModal.tsx
+++ b/packages/round-manager/src/features/common/ErrorModal.tsx
@@ -9,6 +9,7 @@ interface ErrorModalProps {
   heading?: string;
   subheading?: string;
   tryAgainFn?: () => void;
+  doneFn?: () => void;
 }
 
 export default function ErrorModal({
@@ -19,6 +20,7 @@ export default function ErrorModal({
   tryAgainFn = () => {
     /**/
   },
+  doneFn = () => setIsOpen(false),
 }: ErrorModalProps) {
   return (
     <Transition.Root show={isOpen} as={Fragment}>
@@ -90,7 +92,10 @@ export default function ErrorModal({
                     </Button>
                     <Button
                       type="button"
-                      onClick={() => setIsOpen(false)}
+                      onClick={() => {
+                        doneFn();
+                        setIsOpen(false);
+                      }}
                       data-testid="done"
                     >
                       Done

--- a/packages/round-manager/src/features/common/ProgressModal.tsx
+++ b/packages/round-manager/src/features/common/ProgressModal.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { Fragment, ReactNode } from "react";
 import { Dialog, Transition } from "@headlessui/react";
 import { CheckIcon, XIcon } from "@heroicons/react/solid";
 import { ProgressStatus } from "../api/types";
@@ -16,6 +16,7 @@ interface ProgressModalProps {
   heading?: string;
   subheading?: string;
   redirectUrl?: string;
+  children?: ReactNode;
 }
 
 export default function ProgressModal({
@@ -23,6 +24,7 @@ export default function ProgressModal({
   setIsOpen,
   heading = "Processing...",
   subheading = "Please hold while your operation is in progress.",
+  children,
   ...props
 }: ProgressModalProps) {
   return (
@@ -174,6 +176,7 @@ export default function ProgressModal({
         </div>
         {/* Adding invisible button as modal needs to be displayed with a button */}
         <button className="h-0 w-0 overflow-hidden" />
+        {children}
       </Dialog>
     </Transition.Root>
   );

--- a/packages/round-manager/src/features/common/__tests__/ProgressModal.test.tsx
+++ b/packages/round-manager/src/features/common/__tests__/ProgressModal.test.tsx
@@ -191,4 +191,22 @@ describe("<ProgressModal />", () => {
       }
     );
   });
+
+  it("should render children", () => {
+    const expectedTestId = `child-test-id-123`;
+    const child = <div data-testid={expectedTestId} />;
+    renderWrapped(
+      <ProgressModal
+        isOpen
+        setIsOpen={() => {
+          /**/
+        }}
+        steps={steps}
+      >
+        {child}
+      </ProgressModal>
+    );
+
+    expect(screen.getByTestId(expectedTestId)).toBeInTheDocument();
+  });
 });

--- a/packages/round-manager/src/features/program/__tests__/ErrorModal.test.tsx
+++ b/packages/round-manager/src/features/program/__tests__/ErrorModal.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { renderWrapped } from "../../../test-utils";
 import ErrorModal from "../../common/ErrorModal";
 
@@ -25,7 +25,7 @@ describe("<ErrorModal />", () => {
     expect(await screen.findByTestId("error-message")).toBeInTheDocument();
   });
 
-  it("does not show error modal heading when there is no error", async () => {
+  it("does not show error modal heading or message when modal is not open", async () => {
     renderWrapped(
       <ErrorModal
         heading="error title"
@@ -38,5 +38,45 @@ describe("<ErrorModal />", () => {
     );
     expect(screen.queryByTestId("error-heading")).not.toBeInTheDocument();
     expect(screen.queryByTestId("error-message")).not.toBeInTheDocument();
+  });
+
+  it("should call the try again callback and close the modal if try again is clicked", () => {
+    const tryAgainFn = jest.fn();
+    const setIsOpenFn = jest.fn();
+
+    renderWrapped(
+      <ErrorModal
+        heading="error title"
+        subheading="this is an error message"
+        isOpen={true}
+        setIsOpen={setIsOpenFn}
+        tryAgainFn={tryAgainFn}
+      />
+    );
+    fireEvent.click(screen.getByTestId("tryAgain"));
+
+    expect(tryAgainFn).toBeCalledTimes(1);
+    expect(setIsOpenFn).toBeCalledTimes(1);
+    expect(setIsOpenFn).toBeCalledWith(false);
+  });
+
+  it("should call the done callback and close the modal if done is clicked", () => {
+    const doneFn = jest.fn();
+    const setIsOpenFn = jest.fn();
+
+    renderWrapped(
+      <ErrorModal
+        heading="error title"
+        subheading="this is an error message"
+        isOpen={true}
+        setIsOpen={setIsOpenFn}
+        doneFn={doneFn}
+      />
+    );
+    fireEvent.click(screen.getByTestId("done"));
+
+    expect(doneFn).toBeCalledTimes(1);
+    expect(setIsOpenFn).toBeCalledTimes(1);
+    expect(setIsOpenFn).toBeCalledWith(false);
   });
 });

--- a/packages/round-manager/src/features/round/RoundApplicationForm.tsx
+++ b/packages/round-manager/src/features/round/RoundApplicationForm.tsx
@@ -90,7 +90,6 @@ export function RoundApplicationForm(props: {
       contractDeploymentStatus === ProgressStatus.IS_ERROR
     ) {
       setTimeout(() => {
-        setOpenProgressModal(false);
         setOpenErrorModal(true);
       }, errorModalDelayMs);
     }
@@ -221,13 +220,17 @@ export function RoundApplicationForm(props: {
             setIsOpen={setOpenProgressModal}
             subheading={"Please hold while we create your Grant Round."}
             steps={progressSteps}
-          />
-
-          <ErrorModal
-            isOpen={openErrorModal}
-            setIsOpen={setOpenErrorModal}
-            tryAgainFn={handleSubmit(next)}
-          />
+          >
+            <ErrorModal
+              isOpen={openErrorModal}
+              setIsOpen={setOpenErrorModal}
+              tryAgainFn={handleSubmit(next)}
+              doneFn={() => {
+                setOpenErrorModal(false);
+                setOpenProgressModal(false);
+              }}
+            />
+          </ProgressModal>
         </div>
       </div>
     </div>


### PR DESCRIPTION
##### Description

the dialog component from headlessui currently doesn't support simultaneous dialogs.
  even though the progress modal should close at the same time the error modal opens,
  they will exist simultaneously due to the transition animation time.
  the recommended fix is to either nest the dialogs,
  or delay the opening of the second dialog until the end of the first dialog's animation.


##### Refers/Fixes

fixes #449