### PR TITLE
fix(rm): creating program contract throws an error 

### DIFF
--- a/packages/round-manager/src/features/api/program.ts
+++ b/packages/round-manager/src/features/api/program.ts
@@ -169,7 +169,7 @@ export async function deployProgramContract({
   } catch (error) {
     datadogLogs.logger.error(`error: deployProgramContract - ${error}`);
     console.log("error", error);
-    return { error: "Unable to create program" };
+    throw new Error("Unable to create program");
   }
 }
 


### PR DESCRIPTION
##### Description

fix(rm): creating program contract throws an error on signature rejection instead of silent return

deployProgramContract was swallowing any exceptions thrown during execution (such as a transaction rejection), but the caller expected to catch an error for proper status setting

##### Refers/Fixes

fixes #463