### PR TITLE
feat: add progress modal on application details page

### DIFF
--- a/packages/round-manager/src/features/round/__tests__/ApplicationsRejected.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ApplicationsRejected.test.tsx
@@ -252,7 +252,7 @@ describe("<ApplicationsRejected />", () => {
         ).toBeInTheDocument();
       });
 
-      it("starts the bulk update process to persist approved applications when confirm is selected ", async () => {
+      it("starts the bulk update process to persist approved applications when confirm is selected", async () => {
         (updateApplicationList as jest.Mock).mockResolvedValue("");
         (updateRoundContract as jest.Mock).mockReturnValue(
           new Promise(() => {})

--- a/packages/round-manager/src/index.tsx
+++ b/packages/round-manager/src/index.tsx
@@ -85,7 +85,9 @@ root.render(
                   element={
                     <RoundProvider>
                       <ApplicationProvider>
-                        <ViewApplication />
+                        <BulkUpdateGrantApplicationProvider>
+                          <ViewApplication />
+                        </BulkUpdateGrantApplicationProvider>
                       </ApplicationProvider>
                     </RoundProvider>
                   }


### PR DESCRIPTION
##### Description
feat: add progress modal on application details page

- grouped ViewApplicationPage.test.tsx tests into a "verification badges" describe block
- added tests for confirmation modal logic on ViewApplicationPage
- redirect to round page after process completes
- fix margin top on Approve / Reject buttons

##### Refers/Fixes

fix #401 
