### PR TITLE
#353 - Grant Explorer -  add to ballot

### DIFF
--- a/packages/grant-explorer/package.json
+++ b/packages/grant-explorer/package.json
@@ -79,8 +79,12 @@
     "@faker-js/faker": "^7.5.0",
     "@gitcoinco/passport-sdk-types": "^0.2.0",
     "autoprefixer": "^10.4.7",
+    "jest-localstorage-mock": "^2.4.22",
     "postcss": "^8.4.14",
     "tailwind-styled-components": "^2.1.7",
     "tailwindcss": "^3.0.24"
+  },
+  "jest": {
+    "resetMocks": false
   }
 }

--- a/packages/grant-explorer/src/context/BallotContext.tsx
+++ b/packages/grant-explorer/src/context/BallotContext.tsx
@@ -1,0 +1,83 @@
+import { Project } from "../features/api/types";
+import React, {
+  createContext,
+  ReactNode,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { loadShortlist, saveShortlist } from "../features/api/LocalStorage";
+import { RoundContext } from "./RoundContext";
+
+export interface BallotContextState {
+  shortlist: Project[];
+  setShortlist: React.Dispatch<SetStateAction<Project[]>>;
+}
+
+export const initialBallotState: BallotContextState = {
+  shortlist: [],
+  setShortlist: () => {
+    /**/
+  },
+};
+
+export const BallotContext =
+  createContext<BallotContextState>(initialBallotState);
+
+export const BallotProvider = ({ children }: { children: ReactNode }) => {
+  const roundContext = useContext(RoundContext);
+  const currentRoundId = roundContext?.state?.currentRoundId;
+  const [shortlist, setShortlist] = useState(initialBallotState.shortlist);
+
+  useEffect((): void => {
+    if (currentRoundId) {
+      const storedShortlist =
+        loadShortlist(currentRoundId) ?? initialBallotState.shortlist;
+      setShortlist(storedShortlist);
+    }
+  }, [currentRoundId]);
+
+  useEffect((): void => {
+    if (currentRoundId) {
+      saveShortlist(shortlist, currentRoundId);
+    }
+  }, [shortlist, currentRoundId]);
+
+  const providerProps: BallotContextState = {
+    shortlist,
+    setShortlist,
+  };
+
+  return (
+    <BallotContext.Provider value={providerProps}>
+      {children}
+    </BallotContext.Provider>
+  );
+};
+
+/* Custom Hooks */
+type UseBallot = [
+  shortlist: BallotContextState["shortlist"],
+  addProjectToShortlist: (projectToAdd: Project) => void
+];
+export const useBallot = (): UseBallot => {
+  const context = useContext(BallotContext);
+  if (context === undefined) {
+    throw new Error("useBallot must be used within a BallotProvider");
+  }
+
+  const { shortlist, setShortlist } = context;
+
+  const handleAddProjectToShortlist = (projectToAdd: Project): void => {
+    const isProjectAlreadyPresent = shortlist.find(
+      (project) => project.projectRegistryId === projectToAdd.projectRegistryId
+    );
+    const newShortlist = isProjectAlreadyPresent
+      ? shortlist
+      : shortlist.concat(projectToAdd);
+    setShortlist(newShortlist);
+  };
+
+  return [shortlist, handleAddProjectToShortlist];
+};

--- a/packages/grant-explorer/src/context/__tests__/BallotContext.test.tsx
+++ b/packages/grant-explorer/src/context/__tests__/BallotContext.test.tsx
@@ -8,6 +8,10 @@ import { initialRoundState, RoundContext } from "../RoundContext";
 jest.mock("../../features/api/LocalStorage");
 
 describe("<BallotProvider>", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe("when ballot is empty", () => {
     it("should not have any projects in the shortlist", () => {
       render(

--- a/packages/grant-explorer/src/context/__tests__/BallotContext.test.tsx
+++ b/packages/grant-explorer/src/context/__tests__/BallotContext.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BallotProvider, useBallot } from "../BallotContext";
+import { Project } from "../../features/api/types";
+import { makeApprovedProjectData } from "../../test-utils";
+import { loadShortlist, saveShortlist } from "../../features/api/LocalStorage";
+import { initialRoundState, RoundContext } from "../RoundContext";
+
+jest.mock("../../features/api/LocalStorage");
+
+describe("<BallotProvider>", () => {
+  describe("when ballot is empty", () => {
+    it("should not have any projects in the shortlist", () => {
+      render(
+        <BallotProvider>
+          <TestingUseBallotComponent />
+        </BallotProvider>
+      );
+
+      expect(screen.queryAllByTestId("project")).toHaveLength(0);
+    });
+
+    it("should add a project to the shortlist when add project is invoked", () => {
+      render(
+        <BallotProvider>
+          <TestingUseBallotComponent />
+        </BallotProvider>
+      );
+      fireEvent.click(screen.getByTestId("add-project"));
+
+      expect(screen.getAllByTestId("project")).toHaveLength(1);
+    });
+  });
+
+  it("should not add the same project twice to the shortlist", () => {
+    render(
+      <BallotProvider>
+        <TestingUseBallotComponent />
+      </BallotProvider>
+    );
+    fireEvent.click(screen.getByTestId("add-project"));
+    fireEvent.click(screen.getByTestId("add-project"));
+
+    expect(screen.getAllByTestId("project")).toHaveLength(1);
+  });
+
+  it("recovers shortlist when shortlist has been saved", () => {
+    const shortlist: Project[] = [
+      makeApprovedProjectData(),
+      makeApprovedProjectData(),
+    ];
+    (loadShortlist as jest.Mock).mockReturnValue(shortlist);
+
+    render(
+      <RoundContext.Provider
+        value={{
+          state: { ...initialRoundState, currentRoundId: "1" },
+          dispatch: jest.fn(),
+        }}
+      >
+        <BallotProvider>
+          <TestingUseBallotComponent />
+        </BallotProvider>
+      </RoundContext.Provider>
+    );
+
+    expect(screen.getAllByTestId("project")).toHaveLength(shortlist.length);
+    expect(
+      screen.getByText(shortlist[0].projectRegistryId)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(shortlist[1].projectRegistryId)
+    ).toBeInTheDocument();
+  });
+
+  it("should save the shortlist when currently in a round and the shortlist changes", () => {
+    render(
+      <RoundContext.Provider
+        value={{
+          state: { ...initialRoundState, currentRoundId: "1" },
+          dispatch: jest.fn(),
+        }}
+      >
+        <BallotProvider>
+          <TestingUseBallotComponent />
+        </BallotProvider>
+      </RoundContext.Provider>
+    );
+    fireEvent.click(screen.getByTestId("add-project"));
+
+    expect(saveShortlist).toBeCalled();
+  });
+});
+
+const testProject: Project = makeApprovedProjectData();
+const TestingUseBallotComponent = () => {
+  const [shortlist, handleAddProjectToShortlist] = useBallot();
+
+  return (
+    <>
+      {shortlist.map((project, index) => {
+        return (
+          <div key={index} data-testid="project">
+            {`Grant Application Id: ${project.grantApplicationId} 
+            || Project Registry Id: ${project.projectRegistryId}`}
+
+            <span data-testid="project-id">{project.projectRegistryId}</span>
+          </div>
+        );
+      })}
+
+      <button
+        data-testid="add-project"
+        onClick={() => handleAddProjectToShortlist(testProject)}
+      >
+        Add Project
+      </button>
+    </>
+  );
+};

--- a/packages/grant-explorer/src/features/api/LocalStorage.ts
+++ b/packages/grant-explorer/src/features/api/LocalStorage.ts
@@ -1,0 +1,18 @@
+import { Project } from "./types";
+
+export function saveShortlist(shortlist: Project[], roundId: string): void {
+  window.localStorage.setItem(
+    `shortlist-round-${roundId}`,
+    JSON.stringify(shortlist)
+  );
+}
+
+export function loadShortlist(roundId: string): Project[] {
+  const serializedShortlist = window.localStorage.getItem(
+    `shortlist-round-${roundId}`
+  );
+  if (!serializedShortlist) {
+    return [];
+  }
+  return JSON.parse(serializedShortlist);
+}

--- a/packages/grant-explorer/src/features/api/__tests__/localstorage.test.ts
+++ b/packages/grant-explorer/src/features/api/__tests__/localstorage.test.ts
@@ -1,0 +1,58 @@
+import { Project } from "../types";
+import { makeApprovedProjectData } from "../../../test-utils";
+import { loadShortlist, saveShortlist } from "../LocalStorage";
+
+describe("Local Storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it("stores shortlist", () => {
+    const roundId1 = "1";
+    const shortlist: Project[] = [
+      makeApprovedProjectData(),
+      makeApprovedProjectData(),
+    ];
+
+    saveShortlist(shortlist, roundId1);
+
+    expect(localStorage.setItem).toHaveBeenLastCalledWith(
+      `shortlist-round-${roundId1}`,
+      JSON.stringify(shortlist)
+    );
+    expect(localStorage.__STORE__[`shortlist-round-${roundId1}`]).toBe(
+      JSON.stringify(shortlist)
+    );
+    expect(Object.keys(localStorage.__STORE__).length).toBe(1);
+  });
+
+  it("retrieves a shortlist for different rounds", function () {
+    const roundId1 = "1";
+    const roundId2 = "2";
+    const shortlist1: Project[] = [
+      makeApprovedProjectData(),
+      makeApprovedProjectData(),
+    ];
+    const shortlist2: Project[] = [
+      makeApprovedProjectData(),
+      makeApprovedProjectData(),
+    ];
+    localStorage.__STORE__[`shortlist-round-${roundId1}`] =
+      JSON.stringify(shortlist1);
+    localStorage.__STORE__[`shortlist-round-${roundId2}`] =
+      JSON.stringify(shortlist2);
+
+    const list1 = loadShortlist(roundId1);
+    const list2 = loadShortlist(roundId2);
+
+    expect(list1).toEqual(shortlist1);
+    expect(list2).toEqual(shortlist2);
+  });
+
+  it("retrieves empty project list when no shortlist exists", function () {
+    const list = loadShortlist("1");
+
+    expect(list).toEqual([]);
+  });
+});

--- a/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
+++ b/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
@@ -1,10 +1,12 @@
 import { datadogLogs } from "@datadog/browser-logs";
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useRoundById } from "../../context/RoundContext";
 import { ProjectBanner } from "../common/ProjectBanner";
 import DefaultLogoImage from "../../assets/default_logo.png";
 import { ProjectMetadata } from "../api/types";
 import { ChevronLeftIcon } from "@heroicons/react/solid";
+import { Button } from "../common/styles";
 import Navbar from "../common/Navbar";
 
 export default function ViewProjectDetails() {
@@ -19,31 +21,40 @@ export default function ViewProjectDetails() {
     (project) => project.grantApplicationId === applicationId
   );
 
+  const [addedToBallot, setAddedToBallot] = useState(false);
+
   return (
     <>
       <Navbar />
       <div className="container mx-auto h-screen px-4 py-7">
-        <div className="flex flex-row items-center gap-3 text-sm">
-          <ChevronLeftIcon className="h-6 w-6 mt-6 mb-6" />
-          <Link to={`/round/${chainId}/${roundId}`}>
-            <span className="font-normal text-purple-100">Back to Grants</span>
-          </Link>
-        </div>
-        {!isLoading && projectToRender && (
-          <>
-            <Header projectMetadata={projectToRender.projectMetadata} />
-            <div>
-              <ProjectTitle projectMetadata={projectToRender.projectMetadata} />
-              <SectionLine />
-              <Detail text={projectToRender.projectMetadata.website} />
-              <Detail
-                text={`@${projectToRender.projectMetadata.projectTwitter!}`}
+      <div className="flex flex-row items-center gap-3 text-sm">
+        <ChevronLeftIcon className="h-6 w-6 mt-6 mb-6" />
+        <Link to={`/round/${chainId}/${roundId}`}>
+          <span className="font-normal text-purple-100">Back to Grants</span>
+        </Link>
+      </div>
+      {!isLoading && projectToRender && (
+        <>
+          <Header projectMetadata={projectToRender.projectMetadata} />
+          <div>
+            <ProjectTitle projectMetadata={projectToRender.projectMetadata} />
+            <SectionLine />
+            <Detail text={projectToRender.projectMetadata.website} />
+            <Detail
+              text={`@${projectToRender.projectMetadata.projectTwitter!}`}
               />
-              <SectionLine />
-            </div>
-            <div>
-              <DescriptionTitle />
-              <Detail text={projectToRender.projectMetadata.description} />
+            <SectionLine />
+          </div>
+          <div>
+            <DescriptionTitle />
+            <Detail text={projectToRender.projectMetadata.description} />
+          </div>
+          <div>
+            <BallotSelectionToggle
+              isAddedToBallot={addedToBallot}
+              removeFromBallot={() => setAddedToBallot(false)}
+              addToBallot={() => setAddedToBallot(true)}
+            />
             </div>
           </>
         )}
@@ -122,5 +133,28 @@ export function ProjectLogo(props: {
         </div>
       </div>
     </div>
+  );
+}
+
+function BallotSelectionToggle(props: {
+  isAddedToBallot: boolean;
+  addToBallot: () => void;
+  removeFromBallot: () => void;
+}) {
+  return (
+    <>
+      {props.isAddedToBallot ? (
+        <Button
+          data-testid="remove-from-ballot"
+          onClick={props.removeFromBallot}
+        >
+          Remove from ballot
+        </Button>
+      ) : (
+        <Button data-testid="add-to-ballot" onClick={props.addToBallot}>
+          Back this project
+        </Button>
+      )}
+    </>
   );
 }

--- a/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
+++ b/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
@@ -1,5 +1,4 @@
 import { datadogLogs } from "@datadog/browser-logs";
-import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useRoundById } from "../../context/RoundContext";
 import { ProjectBanner } from "../common/ProjectBanner";
@@ -7,6 +6,7 @@ import DefaultLogoImage from "../../assets/default_logo.png";
 import { ProjectMetadata } from "../api/types";
 import { ChevronLeftIcon } from "@heroicons/react/solid";
 import { Button } from "../common/styles";
+import { useBallot } from "../../context/BallotContext";
 import Navbar from "../common/Navbar";
 
 export default function ViewProjectDetails() {
@@ -21,40 +21,46 @@ export default function ViewProjectDetails() {
     (project) => project.grantApplicationId === applicationId
   );
 
-  const [addedToBallot, setAddedToBallot] = useState(false);
+  const [shortlist, addProjectToShortlist] = useBallot();
+  const isAddedToBallot = shortlist.some(
+    (project) => project.grantApplicationId === applicationId
+  );
 
   return (
     <>
       <Navbar />
       <div className="container mx-auto h-screen px-4 py-7">
-      <div className="flex flex-row items-center gap-3 text-sm">
-        <ChevronLeftIcon className="h-6 w-6 mt-6 mb-6" />
-        <Link to={`/round/${chainId}/${roundId}`}>
-          <span className="font-normal text-purple-100">Back to Grants</span>
-        </Link>
-      </div>
-      {!isLoading && projectToRender && (
-        <>
-          <Header projectMetadata={projectToRender.projectMetadata} />
-          <div>
-            <ProjectTitle projectMetadata={projectToRender.projectMetadata} />
-            <SectionLine />
-            <Detail text={projectToRender.projectMetadata.website} />
-            <Detail
-              text={`@${projectToRender.projectMetadata.projectTwitter!}`}
+        <div className="flex flex-row items-center gap-3 text-sm">
+          <ChevronLeftIcon className="h-6 w-6 mt-6 mb-6" />
+          <Link to={`/round/${chainId}/${roundId}`}>
+            <span className="font-normal text-purple-100">Back to Grants</span>
+          </Link>
+        </div>
+        {!isLoading && projectToRender && (
+          <>
+            <Header projectMetadata={projectToRender.projectMetadata} />
+            <div className="flex">
+              <div className="grow">
+                <div>
+                  <ProjectTitle
+                    projectMetadata={projectToRender.projectMetadata}
+                  />
+                  <AboutProject projectToRender={projectToRender} />
+                </div>
+                <div>
+                  <DescriptionTitle />
+                  <Detail text={projectToRender.projectMetadata.description} />
+                </div>
+              </div>
+              <Sidebar
+                addedToBallot={isAddedToBallot}
+                removeFromBallot={() => {
+                  console.log("Not implemented yet");
+                }}
+                addToBallot={() => {
+                  addProjectToShortlist(projectToRender);
+                }}
               />
-            <SectionLine />
-          </div>
-          <div>
-            <DescriptionTitle />
-            <Detail text={projectToRender.projectMetadata.description} />
-          </div>
-          <div>
-            <BallotSelectionToggle
-              isAddedToBallot={addedToBallot}
-              removeFromBallot={() => setAddedToBallot(false)}
-              addToBallot={() => setAddedToBallot(true)}
-            />
             </div>
           </>
         )}
@@ -86,9 +92,22 @@ function Header(props: { projectMetadata: ProjectMetadata }) {
 
 function ProjectTitle(props: { projectMetadata: ProjectMetadata }) {
   return (
-    <h1 className="text-3xl mt-6 font-thin text-purple-100">
-      {props.projectMetadata.title}
-    </h1>
+    <div className="border-b-2 pb-2">
+      <h1 className="text-3xl mt-6 font-thin text-purple-100">
+        {props.projectMetadata.title}
+      </h1>
+    </div>
+  );
+}
+
+function AboutProject(props: { projectToRender: any }) {
+  return (
+    <div className="border-b-2 pt-2 pb-6">
+      <Detail text={props.projectToRender.projectMetadata.website} />
+      <Detail
+        text={`@${props.projectToRender.projectMetadata.projectTwitter!}`}
+      />
+    </div>
   );
 }
 
@@ -104,10 +123,6 @@ function Detail(props: { text: string }) {
   return (
     <p className="text-base font-normal text-purple-100 mt-4">{props.text}</p>
   );
-}
-
-function SectionLine() {
-  return <hr className="my-2 border-2" />;
 }
 
 export function ProjectLogo(props: {
@@ -132,6 +147,22 @@ export function ProjectLogo(props: {
           />
         </div>
       </div>
+    </div>
+  );
+}
+
+function Sidebar(props: {
+  addedToBallot: boolean;
+  removeFromBallot: () => void;
+  addToBallot: () => void;
+}) {
+  return (
+    <div className="ml-6">
+      <BallotSelectionToggle
+        isAddedToBallot={props.addedToBallot}
+        removeFromBallot={props.removeFromBallot}
+        addToBallot={props.addToBallot}
+      />
     </div>
   );
 }

--- a/packages/grant-explorer/src/features/round/__tests__/ViewProjectDetails.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/ViewProjectDetails.test.tsx
@@ -3,7 +3,7 @@ import {
   makeRoundData,
   renderWithContext,
 } from "../../../test-utils";
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import ViewProjectDetails from "../ViewProjectDetails";
 import { faker } from "@faker-js/faker";
 
@@ -121,5 +121,41 @@ describe("<ViewProjectDetails/>", () => {
     }) as HTMLImageElement;
 
     expect(logoImg.src).toContain(expectedProjectLogoImg);
+  });
+});
+
+describe("voting ballot", () => {
+  const expectedProject = makeApprovedProjectData(
+    { grantApplicationId },
+  );
+  const roundWithProjects = makeRoundData({
+    id: roundId,
+    approvedProjects: [expectedProject],
+  });
+
+  it("shows an add-to-ballot button", () => {
+    renderWithContext(<ViewProjectDetails />, { rounds: [roundWithProjects] });
+
+    expect(screen.getByTestId("add-to-ballot")).toBeInTheDocument();
+  });
+
+  it("shows a remove-from-ballot button replacing add-to-ballot when add-to-ballot is clicked", () => {
+    renderWithContext(<ViewProjectDetails />, { rounds: [roundWithProjects] });
+    const addToBallot = screen.getByTestId("add-to-ballot");
+    fireEvent.click(addToBallot);
+
+    expect(screen.getByTestId("remove-from-ballot")).toBeInTheDocument();
+    expect(screen.queryByTestId("add-to-ballot")).not.toBeInTheDocument();
+  });
+
+  it("shows a add-to-ballot when remove-from-ballot is clicked", () => {
+    renderWithContext(<ViewProjectDetails />, { rounds: [roundWithProjects] });
+    const addToBallot = screen.getByTestId("add-to-ballot");
+    fireEvent.click(addToBallot);
+    const removeFromBallot = screen.getByTestId("remove-from-ballot");
+    fireEvent.click(removeFromBallot);
+
+    expect(screen.getByTestId("add-to-ballot")).toBeInTheDocument();
+    expect(screen.queryByTestId("remove-from-ballot")).not.toBeInTheDocument();
   });
 });

--- a/packages/grant-explorer/src/features/round/__tests__/ViewProjectDetails.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/ViewProjectDetails.test.tsx
@@ -80,7 +80,9 @@ describe("<ViewProjectDetails/>", () => {
     });
     renderWithContext(<ViewProjectDetails />, { rounds: [roundWithProjects] });
 
-    expect(await screen.findByText(`@${expectedProjectTwitter}`)).toHaveTextContent(expectedProjectTwitter);
+    expect(
+      await screen.findByText(`@${expectedProjectTwitter}`)
+    ).toHaveTextContent(expectedProjectTwitter);
   });
 
   it("shows project banner", async () => {
@@ -125,9 +127,7 @@ describe("<ViewProjectDetails/>", () => {
 });
 
 describe("voting ballot", () => {
-  const expectedProject = makeApprovedProjectData(
-    { grantApplicationId },
-  );
+  const expectedProject = makeApprovedProjectData({ grantApplicationId });
   const roundWithProjects = makeRoundData({
     id: roundId,
     approvedProjects: [expectedProject],
@@ -146,16 +146,5 @@ describe("voting ballot", () => {
 
     expect(screen.getByTestId("remove-from-ballot")).toBeInTheDocument();
     expect(screen.queryByTestId("add-to-ballot")).not.toBeInTheDocument();
-  });
-
-  it("shows a add-to-ballot when remove-from-ballot is clicked", () => {
-    renderWithContext(<ViewProjectDetails />, { rounds: [roundWithProjects] });
-    const addToBallot = screen.getByTestId("add-to-ballot");
-    fireEvent.click(addToBallot);
-    const removeFromBallot = screen.getByTestId("remove-from-ballot");
-    fireEvent.click(removeFromBallot);
-
-    expect(screen.getByTestId("add-to-ballot")).toBeInTheDocument();
-    expect(screen.queryByTestId("remove-from-ballot")).not.toBeInTheDocument();
   });
 });

--- a/packages/grant-explorer/src/index.tsx
+++ b/packages/grant-explorer/src/index.tsx
@@ -21,6 +21,7 @@ import NotFound from "./features/common/NotFoundPage";
 import AccessDenied from "./features/common/AccessDenied";
 import ViewRound from "./features/round/ViewRoundPage";
 import ViewProjectDetails from "./features/round/ViewProjectDetails";
+import { BallotProvider } from "./context/BallotContext";
 
 // Initialize datadog
 initDatadog();
@@ -35,31 +36,33 @@ root.render(
       <WagmiConfig client={WagmiClient}>
         <RainbowKitProvider chains={chains}>
           <RoundProvider>
-            <ReduxRouter history={history} store={store}>
-              <Routes>
-                {/* Protected Routes */}
-                <Route element={<Auth />}></Route>
+            <BallotProvider>
+              <ReduxRouter history={history} store={store}>
+                <Routes>
+                  {/* Protected Routes */}
+                  <Route element={<Auth />}></Route>
 
-                {/* Default Route */}
-                <Route path="/" element={<NotFound />} />
+                  {/* Default Route */}
+                  <Route path="/" element={<NotFound />} />
 
-                {/* Round Routes */}
-                <Route
-                  path="/round/:chainId/:roundId"
-                  element={<ViewRound />}
-                />
-                <Route
-                  path="/round/:chainId/:roundId/:applicationId"
-                  element={<ViewProjectDetails />}
-                />
+                  {/* Round Routes */}
+                  <Route
+                    path="/round/:chainId/:roundId"
+                    element={<ViewRound />}
+                  />
+                  <Route
+                    path="/round/:chainId/:roundId/:applicationId"
+                    element={<ViewProjectDetails />}
+                  />
 
-                {/* Access Denied */}
-                <Route path="/access-denied" element={<AccessDenied />} />
+                  {/* Access Denied */}
+                  <Route path="/access-denied" element={<AccessDenied />} />
 
-                {/* 404 */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </ReduxRouter>
+                  {/* 404 */}
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </ReduxRouter>
+            </BallotProvider>
           </RoundProvider>
         </RainbowKitProvider>
       </WagmiConfig>

--- a/packages/grant-explorer/src/index.tsx
+++ b/packages/grant-explorer/src/index.tsx
@@ -1,46 +1,44 @@
-import React from "react"
-import ReactDOM from "react-dom/client"
-import { Provider } from "react-redux"
-import { ReduxRouter } from "@lagunovsky/redux-react-router"
-import { RoundProvider } from "./context/RoundContext"
-import { Route, Routes } from "react-router-dom"
-import { WagmiConfig } from "wagmi"
-import { RainbowKitProvider } from '@rainbow-me/rainbowkit'
-import { initDatadog } from "./datadog"
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { Provider } from "react-redux";
+import { ReduxRouter } from "@lagunovsky/redux-react-router";
+import { RoundProvider } from "./context/RoundContext";
+import { Route, Routes } from "react-router-dom";
+import { WagmiConfig } from "wagmi";
+import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
+import { initDatadog } from "./datadog";
 
-import { store } from "./app/store"
-import { chains, client as WagmiClient } from "./app/wagmi"
-import reportWebVitals from "./reportWebVitals"
-import history from "./history"
+import { store } from "./app/store";
+import { chains, client as WagmiClient } from "./app/wagmi";
+import reportWebVitals from "./reportWebVitals";
+import history from "./history";
 
-import "./index.css"
-
+import "./index.css";
 
 // Routes
-import Auth from "./features/common/Auth"
-import NotFound from "./features/common/NotFoundPage"
-import AccessDenied from "./features/common/AccessDenied"
-import ViewRound from "./features/round/ViewRoundPage"
-import ViewProjectDetails from "./features/round/ViewProjectDetails"
+import Auth from "./features/common/Auth";
+import NotFound from "./features/common/NotFoundPage";
+import AccessDenied from "./features/common/AccessDenied";
+import ViewRound from "./features/round/ViewRoundPage";
+import ViewProjectDetails from "./features/round/ViewProjectDetails";
 
 // Initialize datadog
-initDatadog()
+initDatadog();
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
-)
+);
 
 root.render(
-<React.StrictMode>
+  <React.StrictMode>
     <Provider store={store}>
       <WagmiConfig client={WagmiClient}>
         <RainbowKitProvider chains={chains}>
-
-          <ReduxRouter history={history} store={store}>
-            <Routes>
-              {/* Protected Routes */}
-              <Route element={<Auth />}>
-              </Route>
+          <RoundProvider>
+            <ReduxRouter history={history} store={store}>
+              <Routes>
+                {/* Protected Routes */}
+                <Route element={<Auth />}></Route>
 
                 {/* Default Route */}
                 <Route path="/" element={<NotFound />} />
@@ -48,19 +46,11 @@ root.render(
                 {/* Round Routes */}
                 <Route
                   path="/round/:chainId/:roundId"
-                  element={
-                    <RoundProvider>
-                      <ViewRound />
-                    </RoundProvider>
-                  }
+                  element={<ViewRound />}
                 />
                 <Route
                   path="/round/:chainId/:roundId/:applicationId"
-                  element={
-                    <RoundProvider>
-                      <ViewProjectDetails />
-                    </RoundProvider>
-                  }
+                  element={<ViewProjectDetails />}
                 />
 
                 {/* Access Denied */}
@@ -68,9 +58,9 @@ root.render(
 
                 {/* 404 */}
                 <Route path="*" element={<NotFound />} />
-            </Routes>
-          </ReduxRouter>
-
+              </Routes>
+            </ReduxRouter>
+          </RoundProvider>
         </RainbowKitProvider>
       </WagmiConfig>
     </Provider>
@@ -80,4 +70,4 @@ root.render(
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals()
+reportWebVitals();

--- a/packages/grant-explorer/src/setupTests.ts
+++ b/packages/grant-explorer/src/setupTests.ts
@@ -2,4 +2,5 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import "@testing-library/jest-dom/extend-expect";
+require("jest-localstorage-mock");

--- a/packages/grant-explorer/src/test-utils.tsx
+++ b/packages/grant-explorer/src/test-utils.tsx
@@ -6,7 +6,13 @@ import {
   RoundContext,
   RoundState,
 } from "./context/RoundContext";
-import { ApplicationStatus, Project, ProjectMetadata, Round } from "./features/api/types"
+import {
+  ApplicationStatus,
+  Project,
+  ProjectMetadata,
+  Round,
+} from "./features/api/types";
+import { BallotProvider } from "./context/BallotContext";
 
 export const makeRoundData = (overrides: Partial<Round> = {}): Round => {
   const applicationsStartTime = faker.date.soon();
@@ -44,7 +50,10 @@ export const makeRoundData = (overrides: Partial<Round> = {}): Round => {
   };
 };
 
-export const makeApprovedProjectData = (overrides?: Partial<Project>, projectMetadataOverrides?: Partial<ProjectMetadata>): Project => {
+export const makeApprovedProjectData = (
+  overrides?: Partial<Project>,
+  projectMetadataOverrides?: Partial<ProjectMetadata>
+): Project => {
   return {
     grantApplicationId: `${faker.finance.ethereumAddress()}-${faker.finance.ethereumAddress()}`,
     projectRegistryId: faker.datatype.number().toString(),
@@ -52,10 +61,10 @@ export const makeApprovedProjectData = (overrides?: Partial<Project>, projectMet
       title: faker.company.name(),
       description: faker.lorem.sentence(),
       website: faker.internet.url(),
-      ...projectMetadataOverrides
+      ...projectMetadataOverrides,
     },
     status: ApplicationStatus.APPROVED,
-    ...overrides
+    ...overrides,
   };
 };
 
@@ -77,7 +86,7 @@ export const renderWithContext = (
           dispatch,
         }}
       >
-        {ui}
+        <BallotProvider>{ui}</BallotProvider>
       </RoundContext.Provider>
     </MemoryRouter>
   );

--- a/packages/grant-explorer/yarn.lock
+++ b/packages/grant-explorer/yarn.lock
@@ -8434,6 +8434,11 @@ jest-leak-detector@^27.5.1:
     jest-get-type "^27.5.1"
     pretty-format "^27.5.1"
 
+jest-localstorage-mock@^2.4.22:
+  version "2.4.22"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.4.22.tgz#9d70be92bfc591c0be289ee2f71de1b4b2a5ca9b"
+  integrity sha512-60PWSDFQOS5v7JzSmYLM3dPLg0JLl+2Vc4lIEz/rj2yrXJzegsFLn7anwc5IL0WzJbBa/Las064CHbFg491/DQ==
+
 jest-matcher-utils@^27.0.0, jest-matcher-utils@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"


### PR DESCRIPTION
feat: add project to ballot when Back this project is clicked

- wrap RoundProvider around all routes instead of individually
- add ballot selection button to project detail page

fixes #353

**Testing:**
[GE preview link]/#/round/5/0xe7e8c1021da7b811b2303f70ec1a0b5adec8eaf2