### PR TITLE
feat: update QFVotingStrategy to allow native token transfer

### DIFF
--- a/packages/contracts/contracts/round/RoundImplementation.sol
+++ b/packages/contracts/contracts/round/RoundImplementation.sol
@@ -283,7 +283,8 @@ contract RoundImplementation is AccessControlEnumerable, Initializable {
 
   /// @notice Invoked by voter to cast votes
   /// @param encodedVotes encoded vote
-  function vote(bytes[] memory encodedVotes) external {
+  /// @dev value is to handle native token voting
+  function vote(bytes[] memory encodedVotes) external payable {
     // slither-disable-next-line timestamp
     require(
       roundStartTime <= block.timestamp &&
@@ -291,7 +292,7 @@ contract RoundImplementation is AccessControlEnumerable, Initializable {
       "vote: round is not active"
     );
 
-    votingStrategy.vote(encodedVotes, msg.sender);
+    votingStrategy.vote{value: msg.value}(encodedVotes, msg.sender);
   }
 
   /// @notice Invoked by round operator to update distribution on payout contract

--- a/packages/contracts/contracts/votingStrategy/IVotingStrategy.sol
+++ b/packages/contracts/contracts/votingStrategy/IVotingStrategy.sol
@@ -51,5 +51,5 @@ abstract contract IVotingStrategy {
    * @param _encodedVotes encoded votes
    * @param _voterAddress voter address
    */
-  function vote(bytes[] calldata _encodedVotes, address _voterAddress) external virtual;
+  function vote(bytes[] calldata _encodedVotes, address _voterAddress) external virtual payable;
 }

--- a/packages/contracts/contracts/votingStrategy/QuadraticFundingStrategy/QuadraticFundingVotingStrategyImplementation.sol
+++ b/packages/contracts/contracts/votingStrategy/QuadraticFundingStrategy/QuadraticFundingVotingStrategyImplementation.sol
@@ -21,7 +21,7 @@ contract QuadraticFundingVotingStrategyImplementation is IVotingStrategy, Reentr
 
   /// @notice Emitted when a new vote is sent
   event Voted(
-    IERC20Upgradeable  token,         // voting token
+    address  token,                   // voting token
     uint256 amount,                   // voting amount
     address indexed voter,            // voter address
     address indexed grantAddress,     // grant address
@@ -42,29 +42,46 @@ contract QuadraticFundingVotingStrategyImplementation is IVotingStrategy, Reentr
    * - more voters -> higher the gas
    * - this would be triggered when a voter casts their vote via grant explorer
    * - can be invoked by the round
+   * - supports ERC20 and Native token transfer
    *
    * @param encodedVotes encoded list of votes
    * @param voterAddress voter address
    */
-  function vote(bytes[] calldata encodedVotes, address voterAddress) external override nonReentrant isRoundContract {
+  function vote(bytes[] calldata encodedVotes, address voterAddress) external override payable nonReentrant isRoundContract {
+
+    uint256 nativeTokenValue = msg.value;
 
     /// @dev iterate over multiple donations and transfer funds
     for (uint256 i = 0; i < encodedVotes.length; i++) {
 
       (address _token, uint256 _amount, address _grantAddress) = abi.decode(encodedVotes[i], (address, uint256, address));
 
-      /// @dev erc20 transfer to grant address
-      // slither-disable-next-line missing-zero-check,calls-loop,reentrancy-events,arbitrary-send-erc20
-      SafeERC20Upgradeable.safeTransferFrom(
-        IERC20Upgradeable(_token),
-        voterAddress,
-        _grantAddress,
-        _amount
-      );
+      if (_token == address(0)) {
+
+        require (nativeTokenValue >= _amount, "vote: insufficient native token");
+        /// @dev native token transfer to grant address
+        // slither-disable-next-line missing-zero-check,calls-loop,reentrancy-events,arbitrary-send-erc20
+        (bool success, ) = _grantAddress.call{value: _amount}(new bytes(0));
+
+        require(success, "vote: native token transfer failed");
+        nativeTokenValue = nativeTokenValue - _amount;
+
+      } else {
+
+        /// @dev erc20 transfer to grant address
+        // slither-disable-next-line missing-zero-check,calls-loop,reentrancy-events,arbitrary-send-erc20
+        SafeERC20Upgradeable.safeTransferFrom(
+          IERC20Upgradeable(_token),
+          voterAddress,
+          _grantAddress,
+          _amount
+        );
+
+      }
 
       /// @dev emit event for transfer
       emit Voted(
-        IERC20Upgradeable(_token),
+        _token,
         _amount,
         voterAddress,
         _grantAddress,

--- a/packages/contracts/docs/contracts/round/RoundImplementation.md
+++ b/packages/contracts/docs/contracts/round/RoundImplementation.md
@@ -527,12 +527,12 @@ Update roundStartTime (only by ROUND_OPERATOR_ROLE)
 ### vote
 
 ```solidity
-function vote(bytes[] encodedVotes) external nonpayable
+function vote(bytes[] encodedVotes) external payable
 ```
 
 Invoked by voter to cast votes
 
-
+*value is to handle native token voting*
 
 #### Parameters
 

--- a/packages/contracts/docs/contracts/votingStrategy/IVotingStrategy.md
+++ b/packages/contracts/docs/contracts/votingStrategy/IVotingStrategy.md
@@ -41,7 +41,7 @@ Round address
 ### vote
 
 ```solidity
-function vote(bytes[] _encodedVotes, address _voterAddress) external nonpayable
+function vote(bytes[] _encodedVotes, address _voterAddress) external payable
 ```
 
 Invoked by RoundImplementation to allow voter to case vote for grants during a round.

--- a/packages/contracts/docs/contracts/votingStrategy/QuadraticFundingStrategy/QuadraticFundingVotingStrategyImplementation.md
+++ b/packages/contracts/docs/contracts/votingStrategy/QuadraticFundingStrategy/QuadraticFundingVotingStrategyImplementation.md
@@ -52,12 +52,12 @@ Round address
 ### vote
 
 ```solidity
-function vote(bytes[] encodedVotes, address voterAddress) external nonpayable
+function vote(bytes[] encodedVotes, address voterAddress) external payable
 ```
 
 Invoked by RoundImplementation which allows a voted to cast weighted votes to multiple grants during a round
 
-*- more voters -&gt; higher the gas - this would be triggered when a voter casts their vote via grant explorer - can be invoked by the round*
+*- more voters -&gt; higher the gas - this would be triggered when a voter casts their vote via grant explorer - can be invoked by the round - supports ERC20 and Native token transfer*
 
 #### Parameters
 
@@ -89,7 +89,7 @@ event Initialized(uint8 version)
 ### Voted
 
 ```solidity
-event Voted(contract IERC20Upgradeable token, uint256 amount, address indexed voter, address indexed grantAddress, address indexed roundAddress)
+event Voted(address token, uint256 amount, address indexed voter, address indexed grantAddress, address indexed roundAddress)
 ```
 
 Emitted when a new vote is sent
@@ -100,7 +100,7 @@ Emitted when a new vote is sent
 
 | Name | Type | Description |
 |---|---|---|
-| token  | contract IERC20Upgradeable | undefined |
+| token  | address | undefined |
 | amount  | uint256 | undefined |
 | voter `indexed` | address | undefined |
 | grantAddress `indexed` | address | undefined |

--- a/packages/contracts/test/_votingStrategy/QuadraticFundingVotingStrategyImplementation.test.ts
+++ b/packages/contracts/test/_votingStrategy/QuadraticFundingVotingStrategyImplementation.test.ts
@@ -10,420 +10,420 @@ import { AddressZero } from "@ethersproject/constants";
 
 describe("QuadraticFundingVotingStrategyImplementation", () =>  {
 
-	let user: SignerWithAddress;
-	let quadraticFundingVotingStrategy: QuadraticFundingVotingStrategyImplementation;
-	let quadraticFundingVotingStrategyArtifact: Artifact;
+  let user: SignerWithAddress;
+  let quadraticFundingVotingStrategy: QuadraticFundingVotingStrategyImplementation;
+  let quadraticFundingVotingStrategyArtifact: Artifact;
 
-	let mockERC20: MockERC20;
-	let mockERC20Artifact: Artifact;
+  let mockERC20: MockERC20;
+  let mockERC20Artifact: Artifact;
 
-	const tokensToBeMinted = 1000;
+  const tokensToBeMinted = 1000;
 
-	describe('constructor', () => {
+  describe('constructor', () => {
 
-		it('deploys properly', async () => {
+    it('deploys properly', async () => {
 
-			[user] = await ethers.getSigners();
+      [user] = await ethers.getSigners();
 
-			quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-			quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+      quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+      quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-			mockERC20Artifact = await artifacts.readArtifact('MockERC20');
-			mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+      mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+      mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
 
-			// Verify deploy
-			expect(isAddress(quadraticFundingVotingStrategy.address), 'Failed to deploy QuadraticFundingVotingStrategyImplementation').to.be.true;
-			expect(isAddress(mockERC20.address), 'Failed to deploy MockERC20').to.be.true;
+      // Verify deploy
+      expect(isAddress(quadraticFundingVotingStrategy.address), 'Failed to deploy QuadraticFundingVotingStrategyImplementation').to.be.true;
+      expect(isAddress(mockERC20.address), 'Failed to deploy MockERC20').to.be.true;
 
-			// Verify default value
-			expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(AddressZero);
-		});
-	})
+      // Verify default value
+      expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(AddressZero);
+    });
+  })
 
 
-	describe('core functions', () => {
+  describe('core functions', () => { 
 
-		const randomAddress = Wallet.createRandom().address;
+    const randomAddress = Wallet.createRandom().address;
 
-		let grant1 = Wallet.createRandom();
-		const grant1TokenTransferAmount = 150;
-		const grant1NativeTokenTransferAmount = ethers.utils.parseUnits("0.1","ether");
+    let grant1 = Wallet.createRandom();
+    const grant1TokenTransferAmount = 150;
+    const grant1NativeTokenTransferAmount = ethers.utils.parseUnits("0.1","ether");
 
-		let grant2 = Wallet.createRandom();
-		const grant2TokenTransferAmount = 50;
-		const grant2NativeTokenTransferAmount = ethers.utils.parseUnits("0.05","ether");
-		let encodedVotes: BytesLike[] = [];
+    let grant2 = Wallet.createRandom();
+    const grant2TokenTransferAmount = 50;
+    const grant2NativeTokenTransferAmount = ethers.utils.parseUnits("0.05","ether");
+    let encodedVotes: BytesLike[] = [];
 
-		const nativeTokenAddress = AddressZero;
+    const nativeTokenAddress = AddressZero;
 
-		const totalTokenTransfer = grant1TokenTransferAmount + grant2TokenTransferAmount;
+    const totalTokenTransfer = grant1TokenTransferAmount + grant2TokenTransferAmount;
 
 
-		describe('test: init',() => {
-			beforeEach(async () => {
-				[user] = await ethers.getSigners();
+    describe('test: init',() => {
+      beforeEach(async () => {
+        [user] = await ethers.getSigners();
 
-				// Deploy MockERC20 contract
-				mockERC20Artifact = await artifacts.readArtifact('MockERC20');
-				mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+        // Deploy MockERC20 contract
+        mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+        mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
 
-				// Deploy QuadraticFundingVotingStrategy contract
-				quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-				quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+        // Deploy QuadraticFundingVotingStrategy contract
+        quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+        quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-				// Invoke init
-				await quadraticFundingVotingStrategy.init();
-			});
+        // Invoke init
+        await quadraticFundingVotingStrategy.init();
+      });
 
-			it('invoking init once SHOULD set the round address', async () => {
-				expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(user.address);
-			});
+      it('invoking init once SHOULD set the round address', async () => {
+        expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(user.address);
+      });
 
-			it('invoking init more than once SHOULD revert the transaction ', () => {
-				expect(quadraticFundingVotingStrategy.init()).to.revertedWith('init: roundAddress already set')
-			});
-		});
+      it('invoking init more than once SHOULD revert the transaction ', () => {
+        expect(quadraticFundingVotingStrategy.init()).to.revertedWith('init: roundAddress already set')
+      });
+    });
 
-		describe('test: vote', () => {
-			beforeEach(async () => {
-				[user] = await ethers.getSigners();
+    describe('test: vote', () => {
+      beforeEach(async () => {
+        [user] = await ethers.getSigners();
 
-				// Deploy MockERC20 contract
-				mockERC20Artifact = await artifacts.readArtifact('MockERC20');
-				mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+        // Deploy MockERC20 contract
+        mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+        mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
 
-				// Deploy QuadraticFundingVotingStrategyImplementation contract
-				quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-				quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+        // Deploy QuadraticFundingVotingStrategyImplementation contract
+        quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+        quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-				encodedVotes = [];
+        encodedVotes = [];
 
-				// Prepare Votes - only ERC20
-				const votes = [
-					[mockERC20.address, grant1TokenTransferAmount, grant1.address],
-					[mockERC20.address, grant2TokenTransferAmount, grant2.address],
-				];
+        // Prepare Votes - only ERC20
+        const votes = [
+          [mockERC20.address, grant1TokenTransferAmount, grant1.address],
+          [mockERC20.address, grant2TokenTransferAmount, grant2.address],
+        ];
 
-				for (let i = 0; i < votes.length; i++) {
-					encodedVotes.push(
-						ethers.utils.defaultAbiCoder.encode(
-							["address", "uint256", "address"],
-							votes[i]
-						)
-					);
-				}
+        for (let i = 0; i < votes.length; i++) {
+          encodedVotes.push(
+            ethers.utils.defaultAbiCoder.encode(
+              ["address", "uint256", "address"],
+              votes[i]
+            )
+          );
+        }
 
-			});
+      });
 
-			it("invoking vote when roundAddress is not set SHOULD revert transaction", async ()=> {
-				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-				await expect(txn).to.revertedWith('error: voting contract not linked to a round');
-			});
+      it("invoking vote when roundAddress is not set SHOULD revert transaction", async ()=> {
+        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+        await expect(txn).to.revertedWith('error: voting contract not linked to a round');
+      });
 
-			it("invoking vote when sender is not roundAddress SHOULD revert transaction", async ()=> {
+      it("invoking vote when sender is not roundAddress SHOULD revert transaction", async ()=> {
 
-				const [_, anotherUser] = await ethers.getSigners();
+        const [_, anotherUser] = await ethers.getSigners();
 
-				// Invoke init
-				await quadraticFundingVotingStrategy.connect(anotherUser).init();
+        // Invoke init
+        await quadraticFundingVotingStrategy.connect(anotherUser).init();
 
-				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, randomAddress);
-				await expect(txn).to.revertedWith('error: can be invoked only by round contract');
-			});
+        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, randomAddress);
+        await expect(txn).to.revertedWith('error: can be invoked only by round contract');
+      });
 
-			it("invoking vote without allowance SHOULD revert transaction ", async() => {
-				// Invoke init
-				await quadraticFundingVotingStrategy.init();
+      it("invoking vote without allowance SHOULD revert transaction ", async() => {
+        // Invoke init
+        await quadraticFundingVotingStrategy.init();
 
-				const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 0);
-				approveTx.wait();
+        const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 0);
+        approveTx.wait();
 
-				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-				await expect(txn).to.revertedWith('ERC20: insufficient allowance');
-			});
+        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+        await expect(txn).to.revertedWith('ERC20: insufficient allowance');
+      });
 
-			it("invoking vote not enough allowance SHOULD revert transaction ", async() => {
+      it("invoking vote not enough allowance SHOULD revert transaction ", async() => {
 
-				// Invoke init
-				await quadraticFundingVotingStrategy.init();
+        // Invoke init
+        await quadraticFundingVotingStrategy.init();
 
-				const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 100);
-				approveTx.wait();
+        const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 100);
+        approveTx.wait();
 
-				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-				await expect(txn).to.revertedWith('ERC20: insufficient allowance');
+        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+        await expect(txn).to.revertedWith('ERC20: insufficient allowance');
 
-			});
+      });
 
-			describe('test: vote with ERC20', () => {
+      describe('test: vote with ERC20', () => {
 
-				it("invoking vote SHOULD transfer balance from user to grant", async() => {
+        it("invoking vote SHOULD transfer balance from user to grant", async() => {
 
-					// Invoke init
-					await quadraticFundingVotingStrategy.init();
+          // Invoke init
+          await quadraticFundingVotingStrategy.init();
 
-					const beforeVotingUserBalance = await mockERC20.balanceOf(user.address);
-					const beforeVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
-					const beforeVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+          const beforeVotingUserBalance = await mockERC20.balanceOf(user.address);
+          const beforeVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
+          const beforeVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
 
-					expect(beforeVotingGrant1Balance).to.equal("0");
-					expect(beforeVotingGrant2Balance).to.equal("0");
+          expect(beforeVotingGrant1Balance).to.equal("0");
+          expect(beforeVotingGrant2Balance).to.equal("0");
 
-					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
-					approveTx.wait();
+          const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
+          approveTx.wait();
 
-					const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-					txn.wait()
+          const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+          txn.wait()
 
-					const afterVotingUserBalance = await mockERC20.balanceOf(user.address);
-					const afterVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
-					const afterVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+          const afterVotingUserBalance = await mockERC20.balanceOf(user.address);
+          const afterVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
+          const afterVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
 
-					expect(afterVotingUserBalance).to.equal(Number(beforeVotingUserBalance) - totalTokenTransfer);
-					expect(afterVotingGrant1Balance).to.equal(grant1TokenTransferAmount);
-					expect(afterVotingGrant2Balance).to.equal(grant2TokenTransferAmount);
+          expect(afterVotingUserBalance).to.equal(Number(beforeVotingUserBalance) - totalTokenTransfer);
+          expect(afterVotingGrant1Balance).to.equal(grant1TokenTransferAmount);
+          expect(afterVotingGrant2Balance).to.equal(grant2TokenTransferAmount);
 
-				});
+        });
 
-				it("invoking vote SHOULD emit 2 Vote events", async () => {
-					// Invoke init
-					await quadraticFundingVotingStrategy.init();
+        it("invoking vote SHOULD emit 2 Vote events", async () => {
+          // Invoke init
+          await quadraticFundingVotingStrategy.init();
 
-					let votedEvents: Event[] = [];
+          let votedEvents: Event[] = [];
 
-					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
-					approveTx.wait();
+          const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
+          approveTx.wait();
 
-					const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address)
-					txn.wait();
+          const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address)
+          txn.wait();
 
-					// check if vote for first grant fired
-					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-						mockERC20.address,
-						grant1TokenTransferAmount,
-						user.address,
-						grant1.address,
-						user.address // note: this would be the round contract
-					)
+          // check if vote for first grant fired
+          expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+            mockERC20.address,
+            grant1TokenTransferAmount,
+            user.address,
+            grant1.address,
+            user.address // note: this would be the round contract
+          )
 
-					// check if vote for second grant fired
-					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-						mockERC20.address,
-						grant2TokenTransferAmount,
-						user.address,
-						grant2.address,
-						user.address // note: this would be the round contract
-					)
+          // check if vote for second grant fired
+          expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+            mockERC20.address,
+            grant2TokenTransferAmount,
+            user.address,
+            grant2.address,
+            user.address // note: this would be the round contract
+          )
 
-					const receipt = await txn.wait();
-					if (receipt.events) {
-						votedEvents = receipt.events.filter(e => e.event === 'Voted');
-					}
+          const receipt = await txn.wait();
+          if (receipt.events) {
+            votedEvents = receipt.events.filter(e => e.event === 'Voted');
+          }
 
-					expect(votedEvents.length).to.equal(2);
+          expect(votedEvents.length).to.equal(2);
 
-				});
-			});
+        });
+      });
 
 
-			describe('test: vote with native tokens', () => {
+      describe('test: vote with native tokens', () => {
 
-				let encodedVotesInNativeToken: BytesLike[] = [];
+        let encodedVotesInNativeToken: BytesLike[] = [];
 
-				// Prepare Votes - only ERC20
-				const votesInNativeToken = [
-					[nativeTokenAddress, grant1NativeTokenTransferAmount, grant1.address],
-					[nativeTokenAddress, grant2NativeTokenTransferAmount, grant2.address],
-				];
+        // Prepare Votes - only ERC20
+        const votesInNativeToken = [
+          [nativeTokenAddress, grant1NativeTokenTransferAmount, grant1.address],
+          [nativeTokenAddress, grant2NativeTokenTransferAmount, grant2.address],
+        ];
 
-				beforeEach(async () => {
-					// Deploy QuadraticFundingVotingStrategyImplementation contract
-					quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-					quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+        beforeEach(async () => {
+          // Deploy QuadraticFundingVotingStrategyImplementation contract
+          quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+          quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-					// Encode Votes
-					encodedVotesInNativeToken = [];
+          // Encode Votes
+          encodedVotesInNativeToken = [];
 
-					for (let i = 0; i < votesInNativeToken.length; i++) {
-						encodedVotesInNativeToken.push(
-							ethers.utils.defaultAbiCoder.encode(
-								["address", "uint256", "address"],
-								votesInNativeToken[i]
-							)
-						);
-					}
-				})
+          for (let i = 0; i < votesInNativeToken.length; i++) {
+            encodedVotesInNativeToken.push(
+              ethers.utils.defaultAbiCoder.encode(
+                ["address", "uint256", "address"],
+                votesInNativeToken[i]
+              )
+            );
+          }
+        })
 
-				it.only("invoking vote SHOULD rever if there are insufficent funds", async() => {
-					// Invoke init
-					await quadraticFundingVotingStrategy.init();
+        it("invoking vote SHOULD revert if there are insufficent funds", async() => {
+          // Invoke init
+          await quadraticFundingVotingStrategy.init();
 
-					const txn = quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '100000000000000000'});
+          const txn = quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '100000000000000000'});
 
-					await expect(txn).to.revertedWith("vote: insufficient native token");
-				});
+          await expect(txn).to.revertedWith("Address: insufficient balance");
+        });
 
 
-				it("invoking vote SHOULD transfer balance from user to grant", async() => {
-					// Invoke init
-					await quadraticFundingVotingStrategy.init();
+        it("invoking vote SHOULD transfer balance from user to grant", async() => {
+          // Invoke init
+          await quadraticFundingVotingStrategy.init();
 
-					const beforeVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
-					const beforeVotingGrant2Balance = await ethers.provider.getBalance(grant2.address);
+          const beforeVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+          const beforeVotingGrant2Balance = await ethers.provider.getBalance(grant2.address);
 
-					expect(beforeVotingGrant1Balance).to.equal("0");
-					expect(beforeVotingGrant2Balance).to.equal("0");
+          expect(beforeVotingGrant1Balance).to.equal("0");
+          expect(beforeVotingGrant2Balance).to.equal("0");
 
-					await quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '150000000000000000'});
+          await quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '150000000000000000'});
 
-					const afterVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
-					const afterVotingGrant2Balance = await ethers.provider.getBalance(grant2.address);
+          const afterVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+          const afterVotingGrant2Balance = await ethers.provider.getBalance(grant2.address);
 
-					expect(afterVotingGrant1Balance).to.equal(grant1NativeTokenTransferAmount);
-					expect(afterVotingGrant2Balance).to.equal(grant2NativeTokenTransferAmount);
-				});
+          expect(afterVotingGrant1Balance).to.equal(grant1NativeTokenTransferAmount);
+          expect(afterVotingGrant2Balance).to.equal(grant2NativeTokenTransferAmount);
+        });
 
-				it("invoking vote SHOULD emit 2 Vote events", async () => {
+        it("invoking vote SHOULD emit 2 Vote events", async () => {
 
-					let votedEvents: Event[] = [];
+          let votedEvents: Event[] = [];
 
-					// Invoke init
-					await quadraticFundingVotingStrategy.init();
+          // Invoke init
+          await quadraticFundingVotingStrategy.init();
 
-					const txn = await quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '150000000000000000'});
+          const txn = await quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '150000000000000000'});
 
-					// check if vote for first grant fired
-					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-						nativeTokenAddress,
-						grant1NativeTokenTransferAmount,
-						user.address,
-						grant1.address,
-						user.address // note: this would be the round contract
-					)
+          // check if vote for first grant fired
+          expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+            nativeTokenAddress,
+            grant1NativeTokenTransferAmount,
+            user.address,
+            grant1.address,
+            user.address // note: this would be the round contract
+          )
 
-					// check if vote for second grant fired
-					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-						nativeTokenAddress,
-						grant2NativeTokenTransferAmount,
-						user.address,
-						grant2.address,
-						user.address // note: this would be the round contract
-					)
+          // check if vote for second grant fired
+          expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+            nativeTokenAddress,
+            grant2NativeTokenTransferAmount,
+            user.address,
+            grant2.address,
+            user.address // note: this would be the round contract
+          )
 
-					const receipt = await txn.wait();
-					if (receipt.events) {
-						votedEvents = receipt.events.filter(e => e.event === 'Voted');
-					}
+          const receipt = await txn.wait();
+          if (receipt.events) {
+            votedEvents = receipt.events.filter(e => e.event === 'Voted');
+          }
 
-					expect(votedEvents.length).to.equal(2);
+          expect(votedEvents.length).to.equal(2);
 
-				});
+        });
 
-			});
+      });
 
-			describe('test: vote with native and ERC20 tokens', () => {
+      describe('test: vote with native and ERC20 tokens', () => {
 
-				let encodedVotes: BytesLike[] = [];
+        let encodedVotes: BytesLike[] = [];
 
 
-				beforeEach(async () => {
+        beforeEach(async () => {
 
-					grant1 = Wallet.createRandom();
-					grant2 = Wallet.createRandom();
+          grant1 = Wallet.createRandom();
+          grant2 = Wallet.createRandom();
 
-					// Deploy QuadraticFundingVotingStrategyImplementation contract
-					quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-					quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+          // Deploy QuadraticFundingVotingStrategyImplementation contract
+          quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+          quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-					mockERC20Artifact = await artifacts.readArtifact('MockERC20');
-					mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+          mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+          mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
 
 
-					// Prepare Votes - Native Token + ERC20
-					const votes = [
-						[nativeTokenAddress, grant1NativeTokenTransferAmount, grant1.address],
-						[mockERC20.address, grant2TokenTransferAmount, grant2.address],
-					];
+          // Prepare Votes - Native Token + ERC20
+          const votes = [
+            [nativeTokenAddress, grant1NativeTokenTransferAmount, grant1.address],
+            [mockERC20.address, grant2TokenTransferAmount, grant2.address],
+          ];
 
-					// Encode Votes
-					encodedVotes = [];
+          // Encode Votes
+          encodedVotes = [];
 
-					for (let i = 0; i < votes.length; i++) {
-						encodedVotes.push(
-							ethers.utils.defaultAbiCoder.encode(
-								["address", "uint256", "address"],
-								votes[i]
-							)
-						);
-					}
-				})
+          for (let i = 0; i < votes.length; i++) {
+            encodedVotes.push(
+              ethers.utils.defaultAbiCoder.encode(
+                ["address", "uint256", "address"],
+                votes[i]
+              )
+            );
+          }
+        })
 
-				it("invoking vote SHOULD transfer balance from user to grant", async() => {
+        it("invoking vote SHOULD transfer balance from user to grant", async() => {
 
-					// Invoke init
-					await quadraticFundingVotingStrategy.init();
+          // Invoke init
+          await quadraticFundingVotingStrategy.init();
 
-					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, grant2TokenTransferAmount);
-					approveTx.wait();
+          const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, grant2TokenTransferAmount);
+          approveTx.wait();
 
-					const beforeVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
-					const beforeVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+          const beforeVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+          const beforeVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
 
-					expect(beforeVotingGrant1Balance).to.equal("0");
-					expect(beforeVotingGrant2Balance).to.equal("0");
+          expect(beforeVotingGrant1Balance).to.equal("0");
+          expect(beforeVotingGrant2Balance).to.equal("0");
 
-					await quadraticFundingVotingStrategy.vote(encodedVotes, user.address, {value: '100000000000000000'});
+          await quadraticFundingVotingStrategy.vote(encodedVotes, user.address, {value: '100000000000000000'});
 
-					const afterVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
-					const afterVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+          const afterVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+          const afterVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
 
-					expect(afterVotingGrant1Balance).to.equal(grant1NativeTokenTransferAmount);
-					expect(afterVotingGrant2Balance).to.equal(grant2TokenTransferAmount);
-				});
+          expect(afterVotingGrant1Balance).to.equal(grant1NativeTokenTransferAmount);
+          expect(afterVotingGrant2Balance).to.equal(grant2TokenTransferAmount);
+        });
 
-				it("invoking vote SHOULD emit 2 Vote events", async () => {
+        it("invoking vote SHOULD emit 2 Vote events", async () => {
 
-					let votedEvents: Event[] = [];
+          let votedEvents: Event[] = [];
 
-					// Invoke init
-					await quadraticFundingVotingStrategy.init();
+          // Invoke init
+          await quadraticFundingVotingStrategy.init();
 
-					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
-					approveTx.wait();
+          const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
+          approveTx.wait();
 
-					const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address, {value: '100000000000000000'});
+          const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address, {value: '100000000000000000'});
 
-					// check if vote for first grant fired
-					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-						nativeTokenAddress,
-						grant1NativeTokenTransferAmount,
-						user.address,
-						grant1.address,
-						user.address // note: this would be the round contract
-					)
+          // check if vote for first grant fired
+          expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+            nativeTokenAddress,
+            grant1NativeTokenTransferAmount,
+            user.address,
+            grant1.address,
+            user.address // note: this would be the round contract
+          )
 
-					// check if vote for second grant fired
-					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-						mockERC20.address,
-						grant2TokenTransferAmount,
-						user.address,
-						grant2.address,
-						user.address // note: this would be the round contract
-					)
+          // check if vote for second grant fired
+          expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+            mockERC20.address,
+            grant2TokenTransferAmount,
+            user.address,
+            grant2.address,
+            user.address // note: this would be the round contract
+          )
 
-					const receipt = await txn.wait();
-					if (receipt.events) {
-						votedEvents = receipt.events.filter(e => e.event === 'Voted');
-					}
+          const receipt = await txn.wait();
+          if (receipt.events) {
+            votedEvents = receipt.events.filter(e => e.event === 'Voted');
+          }
 
-					expect(votedEvents.length).to.equal(2);
+          expect(votedEvents.length).to.equal(2);
 
-				});
+        });
 
-			});
+      });
 
-		});
+    });
 
-	});
+  });
 
 });

--- a/packages/contracts/test/_votingStrategy/QuadraticFundingVotingStrategyImplementation.test.ts
+++ b/packages/contracts/test/_votingStrategy/QuadraticFundingVotingStrategyImplementation.test.ts
@@ -10,216 +10,420 @@ import { AddressZero } from "@ethersproject/constants";
 
 describe("QuadraticFundingVotingStrategyImplementation", () =>  {
 
-  let user: SignerWithAddress;
-  let quadraticFundingVotingStrategy: QuadraticFundingVotingStrategyImplementation;
-  let quadraticFundingVotingStrategyArtifact: Artifact;
+	let user: SignerWithAddress;
+	let quadraticFundingVotingStrategy: QuadraticFundingVotingStrategyImplementation;
+	let quadraticFundingVotingStrategyArtifact: Artifact;
 
-  let mockERC20: MockERC20;
-  let mockERC20Artifact: Artifact;
+	let mockERC20: MockERC20;
+	let mockERC20Artifact: Artifact;
 
-  const tokensToBeMinted = 1000;
+	const tokensToBeMinted = 1000;
 
-  describe('constructor', () => {
+	describe('constructor', () => {
 
-    it('deploys properly', async () => {
+		it('deploys properly', async () => {
 
-      [user] = await ethers.getSigners();
+			[user] = await ethers.getSigners();
 
-      quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-      quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+			quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+			quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-      mockERC20Artifact = await artifacts.readArtifact('MockERC20');
-      mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+			mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+			mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
 
-      // Verify deploy
-      expect(isAddress(quadraticFundingVotingStrategy.address), 'Failed to deploy QuadraticFundingVotingStrategyImplementation').to.be.true;
-      expect(isAddress(mockERC20.address), 'Failed to deploy MockERC20').to.be.true;
+			// Verify deploy
+			expect(isAddress(quadraticFundingVotingStrategy.address), 'Failed to deploy QuadraticFundingVotingStrategyImplementation').to.be.true;
+			expect(isAddress(mockERC20.address), 'Failed to deploy MockERC20').to.be.true;
 
-      // Verify default value
-      expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(AddressZero);
-    });
-  })
-
-
-  describe('core functions', () => {
-
-    const randomAddress = Wallet.createRandom().address;
-
-    const grant1 = Wallet.createRandom();
-    const grant1TokenTransferAmount = 150;
-
-    const grant2 = Wallet.createRandom();
-    const grant2TokenTransferAmount = 50;
-    let encodedVotes: BytesLike[] = [];
-
-    const totalTokenTransfer = grant1TokenTransferAmount + grant2TokenTransferAmount;
+			// Verify default value
+			expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(AddressZero);
+		});
+	})
 
 
-    describe('test: init',() => {
-      beforeEach(async () => {
-        [user] = await ethers.getSigners();
+	describe('core functions', () => {
 
-        // Deploy MockERC20 contract
-        mockERC20Artifact = await artifacts.readArtifact('MockERC20');
-        mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+		const randomAddress = Wallet.createRandom().address;
 
-        // Deploy QuadraticFundingVotingStrategy contract
-        quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-        quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+		let grant1 = Wallet.createRandom();
+		const grant1TokenTransferAmount = 150;
+		const grant1NativeTokenTransferAmount = ethers.utils.parseUnits("0.1","ether");
 
-        // Invoke init
-        await quadraticFundingVotingStrategy.init();
-      });
+		let grant2 = Wallet.createRandom();
+		const grant2TokenTransferAmount = 50;
+		const grant2NativeTokenTransferAmount = ethers.utils.parseUnits("0.05","ether");
+		let encodedVotes: BytesLike[] = [];
 
-      it('invoking init once SHOULD set the round address', async () => {
-        expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(user.address);
-      });
+		const nativeTokenAddress = AddressZero;
 
-      it('invoking init more than once SHOULD revert the transaction ', () => {
-        expect(quadraticFundingVotingStrategy.init()).to.revertedWith('init: roundAddress already set')
-      });
-    });
+		const totalTokenTransfer = grant1TokenTransferAmount + grant2TokenTransferAmount;
 
-    describe('test: vote', () => {
-      beforeEach(async () => {
-        [user] = await ethers.getSigners();
 
-        // Deploy MockERC20 contract
-        mockERC20Artifact = await artifacts.readArtifact('MockERC20');
-        mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+		describe('test: init',() => {
+			beforeEach(async () => {
+				[user] = await ethers.getSigners();
 
-        // Deploy QuadraticFundingVotingStrategyImplementation contract
-        quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
-        quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+				// Deploy MockERC20 contract
+				mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+				mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
 
-        encodedVotes = [];
+				// Deploy QuadraticFundingVotingStrategy contract
+				quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+				quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-        // Prepare Votes
-        const votes = [
-          [mockERC20.address, grant1TokenTransferAmount, grant1.address],
-          [mockERC20.address, grant2TokenTransferAmount, grant2.address],
-        ];
+				// Invoke init
+				await quadraticFundingVotingStrategy.init();
+			});
 
-        for (let i = 0; i < votes.length; i++) {
-          encodedVotes.push(
-            ethers.utils.defaultAbiCoder.encode(
-              ["address", "uint256", "address"],
-              votes[i]
-            )
-          );
-        }
+			it('invoking init once SHOULD set the round address', async () => {
+				expect(await quadraticFundingVotingStrategy.roundAddress()).to.equal(user.address);
+			});
 
-      });
+			it('invoking init more than once SHOULD revert the transaction ', () => {
+				expect(quadraticFundingVotingStrategy.init()).to.revertedWith('init: roundAddress already set')
+			});
+		});
 
-      it("invoking vote when roundAddress is not set SHOULD rever transaction", async ()=> {
-        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-        await expect(txn).to.revertedWith('error: voting contract not linked to a round');
-      });
+		describe('test: vote', () => {
+			beforeEach(async () => {
+				[user] = await ethers.getSigners();
 
-      it("invoking vote when sender is not roundAddress SHOULD revert transaction", async ()=> {
+				// Deploy MockERC20 contract
+				mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+				mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
 
-        const [_, anotherUser] = await ethers.getSigners();
+				// Deploy QuadraticFundingVotingStrategyImplementation contract
+				quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+				quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
 
-        // Invoke init
-        await quadraticFundingVotingStrategy.connect(anotherUser).init();
+				encodedVotes = [];
 
-        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, randomAddress);
-        await expect(txn).to.revertedWith('error: can be invoked only by round contract');
-      });
+				// Prepare Votes - only ERC20
+				const votes = [
+					[mockERC20.address, grant1TokenTransferAmount, grant1.address],
+					[mockERC20.address, grant2TokenTransferAmount, grant2.address],
+				];
 
-      it("invoking vote without allowance SHOULD revert transaction ", async() => {
-        // Invoke init
-        await quadraticFundingVotingStrategy.init();
+				for (let i = 0; i < votes.length; i++) {
+					encodedVotes.push(
+						ethers.utils.defaultAbiCoder.encode(
+							["address", "uint256", "address"],
+							votes[i]
+						)
+					);
+				}
 
-        const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 0);
-        approveTx.wait();
+			});
 
-        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-        await expect(txn).to.revertedWith('ERC20: insufficient allowance');
-      });
+			it("invoking vote when roundAddress is not set SHOULD revert transaction", async ()=> {
+				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+				await expect(txn).to.revertedWith('error: voting contract not linked to a round');
+			});
 
-      it("invoking vote not enough allowance SHOULD revert transaction ", async() => {
+			it("invoking vote when sender is not roundAddress SHOULD revert transaction", async ()=> {
 
-        // Invoke init
-        await quadraticFundingVotingStrategy.init();
+				const [_, anotherUser] = await ethers.getSigners();
 
-        const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 100);
-        approveTx.wait();
+				// Invoke init
+				await quadraticFundingVotingStrategy.connect(anotherUser).init();
 
-        const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-        await expect(txn).to.revertedWith('ERC20: insufficient allowance');
+				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, randomAddress);
+				await expect(txn).to.revertedWith('error: can be invoked only by round contract');
+			});
 
-      });
+			it("invoking vote without allowance SHOULD revert transaction ", async() => {
+				// Invoke init
+				await quadraticFundingVotingStrategy.init();
 
-      it("invoking vote SHOULD transfer balance from user to grant", async() => {
+				const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 0);
+				approveTx.wait();
 
-        // Invoke init
-        await quadraticFundingVotingStrategy.init();
+				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+				await expect(txn).to.revertedWith('ERC20: insufficient allowance');
+			});
 
-        const beforeVotingUserBalance = await mockERC20.balanceOf(user.address);
-        const beforeVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
-        const beforeVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+			it("invoking vote not enough allowance SHOULD revert transaction ", async() => {
 
-        expect(beforeVotingGrant1Balance).to.equal("0");
-        expect(beforeVotingGrant2Balance).to.equal("0");
+				// Invoke init
+				await quadraticFundingVotingStrategy.init();
 
-        const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
-        approveTx.wait();
+				const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, 100);
+				approveTx.wait();
 
-        const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
-        txn.wait()
+				const txn =  quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+				await expect(txn).to.revertedWith('ERC20: insufficient allowance');
 
-        const afterVotingUserBalance = await mockERC20.balanceOf(user.address);
-        const afterVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
-        const afterVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+			});
 
-        expect(afterVotingUserBalance).to.equal(Number(beforeVotingUserBalance) - totalTokenTransfer);
-        expect(afterVotingGrant1Balance).to.equal(grant1TokenTransferAmount);
-        expect(afterVotingGrant2Balance).to.equal(grant2TokenTransferAmount);
+			describe('test: vote with ERC20', () => {
 
-      });
+				it("invoking vote SHOULD transfer balance from user to grant", async() => {
 
-      it("invoking vote SHOULD emit 2 Vote events", async () => {
-        // Invoke init
-        await quadraticFundingVotingStrategy.init();
+					// Invoke init
+					await quadraticFundingVotingStrategy.init();
 
-        let votedEvents: Event[] = [];
+					const beforeVotingUserBalance = await mockERC20.balanceOf(user.address);
+					const beforeVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
+					const beforeVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
 
-        const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
-        approveTx.wait();
+					expect(beforeVotingGrant1Balance).to.equal("0");
+					expect(beforeVotingGrant2Balance).to.equal("0");
 
-        const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address)
-        txn.wait();
+					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
+					approveTx.wait();
 
-        // check if vote for first grant fired
-        expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-          mockERC20.address,
-          grant1TokenTransferAmount,
-          user.address,
-          grant1.address,
-          user.address // note: this would be the round contract
-        )
+					const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address);
+					txn.wait()
 
-        // check if vote for second grant fired
-        expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
-          mockERC20.address,
-          grant2TokenTransferAmount,
-          user.address,
-          grant2.address,
-          user.address // note: this would be the round contract
-        )
+					const afterVotingUserBalance = await mockERC20.balanceOf(user.address);
+					const afterVotingGrant1Balance = await mockERC20.balanceOf(grant1.address);
+					const afterVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
 
-        const receipt = await txn.wait();
-        if (receipt.events) {
-          votedEvents = receipt.events.filter(e => e.event === 'Voted');
-        }
+					expect(afterVotingUserBalance).to.equal(Number(beforeVotingUserBalance) - totalTokenTransfer);
+					expect(afterVotingGrant1Balance).to.equal(grant1TokenTransferAmount);
+					expect(afterVotingGrant2Balance).to.equal(grant2TokenTransferAmount);
 
-        expect(votedEvents.length).to.equal(2);
+				});
 
-      });
+				it("invoking vote SHOULD emit 2 Vote events", async () => {
+					// Invoke init
+					await quadraticFundingVotingStrategy.init();
 
-    });
+					let votedEvents: Event[] = [];
 
-  });
+					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
+					approveTx.wait();
+
+					const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address)
+					txn.wait();
+
+					// check if vote for first grant fired
+					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+						mockERC20.address,
+						grant1TokenTransferAmount,
+						user.address,
+						grant1.address,
+						user.address // note: this would be the round contract
+					)
+
+					// check if vote for second grant fired
+					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+						mockERC20.address,
+						grant2TokenTransferAmount,
+						user.address,
+						grant2.address,
+						user.address // note: this would be the round contract
+					)
+
+					const receipt = await txn.wait();
+					if (receipt.events) {
+						votedEvents = receipt.events.filter(e => e.event === 'Voted');
+					}
+
+					expect(votedEvents.length).to.equal(2);
+
+				});
+			});
+
+
+			describe('test: vote with native tokens', () => {
+
+				let encodedVotesInNativeToken: BytesLike[] = [];
+
+				// Prepare Votes - only ERC20
+				const votesInNativeToken = [
+					[nativeTokenAddress, grant1NativeTokenTransferAmount, grant1.address],
+					[nativeTokenAddress, grant2NativeTokenTransferAmount, grant2.address],
+				];
+
+				beforeEach(async () => {
+					// Deploy QuadraticFundingVotingStrategyImplementation contract
+					quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+					quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+
+					// Encode Votes
+					encodedVotesInNativeToken = [];
+
+					for (let i = 0; i < votesInNativeToken.length; i++) {
+						encodedVotesInNativeToken.push(
+							ethers.utils.defaultAbiCoder.encode(
+								["address", "uint256", "address"],
+								votesInNativeToken[i]
+							)
+						);
+					}
+				})
+
+				it.only("invoking vote SHOULD rever if there are insufficent funds", async() => {
+					// Invoke init
+					await quadraticFundingVotingStrategy.init();
+
+					const txn = quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '100000000000000000'});
+
+					await expect(txn).to.revertedWith("vote: insufficient native token");
+				});
+
+
+				it("invoking vote SHOULD transfer balance from user to grant", async() => {
+					// Invoke init
+					await quadraticFundingVotingStrategy.init();
+
+					const beforeVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+					const beforeVotingGrant2Balance = await ethers.provider.getBalance(grant2.address);
+
+					expect(beforeVotingGrant1Balance).to.equal("0");
+					expect(beforeVotingGrant2Balance).to.equal("0");
+
+					await quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '150000000000000000'});
+
+					const afterVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+					const afterVotingGrant2Balance = await ethers.provider.getBalance(grant2.address);
+
+					expect(afterVotingGrant1Balance).to.equal(grant1NativeTokenTransferAmount);
+					expect(afterVotingGrant2Balance).to.equal(grant2NativeTokenTransferAmount);
+				});
+
+				it("invoking vote SHOULD emit 2 Vote events", async () => {
+
+					let votedEvents: Event[] = [];
+
+					// Invoke init
+					await quadraticFundingVotingStrategy.init();
+
+					const txn = await quadraticFundingVotingStrategy.vote(encodedVotesInNativeToken, user.address, {value: '150000000000000000'});
+
+					// check if vote for first grant fired
+					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+						nativeTokenAddress,
+						grant1NativeTokenTransferAmount,
+						user.address,
+						grant1.address,
+						user.address // note: this would be the round contract
+					)
+
+					// check if vote for second grant fired
+					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+						nativeTokenAddress,
+						grant2NativeTokenTransferAmount,
+						user.address,
+						grant2.address,
+						user.address // note: this would be the round contract
+					)
+
+					const receipt = await txn.wait();
+					if (receipt.events) {
+						votedEvents = receipt.events.filter(e => e.event === 'Voted');
+					}
+
+					expect(votedEvents.length).to.equal(2);
+
+				});
+
+			});
+
+			describe('test: vote with native and ERC20 tokens', () => {
+
+				let encodedVotes: BytesLike[] = [];
+
+
+				beforeEach(async () => {
+
+					grant1 = Wallet.createRandom();
+					grant2 = Wallet.createRandom();
+
+					// Deploy QuadraticFundingVotingStrategyImplementation contract
+					quadraticFundingVotingStrategyArtifact = await artifacts.readArtifact('QuadraticFundingVotingStrategyImplementation');
+					quadraticFundingVotingStrategy = <QuadraticFundingVotingStrategyImplementation>await deployContract(user, quadraticFundingVotingStrategyArtifact, []);
+
+					mockERC20Artifact = await artifacts.readArtifact('MockERC20');
+					mockERC20 = <MockERC20>await deployContract(user, mockERC20Artifact, [tokensToBeMinted]);
+
+
+					// Prepare Votes - Native Token + ERC20
+					const votes = [
+						[nativeTokenAddress, grant1NativeTokenTransferAmount, grant1.address],
+						[mockERC20.address, grant2TokenTransferAmount, grant2.address],
+					];
+
+					// Encode Votes
+					encodedVotes = [];
+
+					for (let i = 0; i < votes.length; i++) {
+						encodedVotes.push(
+							ethers.utils.defaultAbiCoder.encode(
+								["address", "uint256", "address"],
+								votes[i]
+							)
+						);
+					}
+				})
+
+				it("invoking vote SHOULD transfer balance from user to grant", async() => {
+
+					// Invoke init
+					await quadraticFundingVotingStrategy.init();
+
+					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, grant2TokenTransferAmount);
+					approveTx.wait();
+
+					const beforeVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+					const beforeVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+
+					expect(beforeVotingGrant1Balance).to.equal("0");
+					expect(beforeVotingGrant2Balance).to.equal("0");
+
+					await quadraticFundingVotingStrategy.vote(encodedVotes, user.address, {value: '100000000000000000'});
+
+					const afterVotingGrant1Balance = await ethers.provider.getBalance(grant1.address);
+					const afterVotingGrant2Balance = await mockERC20.balanceOf(grant2.address);
+
+					expect(afterVotingGrant1Balance).to.equal(grant1NativeTokenTransferAmount);
+					expect(afterVotingGrant2Balance).to.equal(grant2TokenTransferAmount);
+				});
+
+				it("invoking vote SHOULD emit 2 Vote events", async () => {
+
+					let votedEvents: Event[] = [];
+
+					// Invoke init
+					await quadraticFundingVotingStrategy.init();
+
+					const approveTx = await mockERC20.approve(quadraticFundingVotingStrategy.address, totalTokenTransfer);
+					approveTx.wait();
+
+					const txn = await quadraticFundingVotingStrategy.vote(encodedVotes, user.address, {value: '100000000000000000'});
+
+					// check if vote for first grant fired
+					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+						nativeTokenAddress,
+						grant1NativeTokenTransferAmount,
+						user.address,
+						grant1.address,
+						user.address // note: this would be the round contract
+					)
+
+					// check if vote for second grant fired
+					expect(txn).to.emit(quadraticFundingVotingStrategy, 'Voted').withArgs(
+						mockERC20.address,
+						grant2TokenTransferAmount,
+						user.address,
+						grant2.address,
+						user.address // note: this would be the round contract
+					)
+
+					const receipt = await txn.wait();
+					if (receipt.events) {
+						votedEvents = receipt.events.filter(e => e.event === 'Voted');
+					}
+
+					expect(votedEvents.length).to.equal(2);
+
+				});
+
+			});
+
+		});
+
+	});
 
 });

--- a/packages/contracts/test/payoutStrategy/MerklePayoutStrategy.test.ts
+++ b/packages/contracts/test/payoutStrategy/MerklePayoutStrategy.test.ts
@@ -33,7 +33,7 @@ describe("MerklePayoutStrategy", () =>  {
 
       expect(await merklePayoutStrategy.roundAddress()).to.equal(AddressZero);
     });
-  })
+  });
 
   describe('core functions', () => {
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

The goal here is to update the QFVotingStrategyImplementation contract to support native tokens transfer and not just ERC20.
All we would have to do here in the vote function :
- [x] if address == 0x -> do a regular transfer else do a ERC20 transfer

##### Refers/Fixes
fixes #496 

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
