### PR TITLE
Add round details to application view page

### DIFF
--- a/packages/grant-explorer/src/features/api/round.ts
+++ b/packages/grant-explorer/src/features/api/round.ts
@@ -1,5 +1,11 @@
 import { fetchFromIPFS, graphql_fetch } from "./utils";
-import { ApplicationStatus, MetadataPointer, Project, Round } from "./types";
+import {
+  ApplicationStatus,
+  Eligibility,
+  MetadataPointer,
+  Project,
+  Round,
+} from "./types";
 
 /**
  * Shape of subgraph response
@@ -41,6 +47,7 @@ interface RoundProjectResult {
  */
 type RoundMetadata = {
   name: string;
+  eligibility: Eligibility;
   programContractAddress: string;
 };
 

--- a/packages/grant-explorer/src/features/api/types.ts
+++ b/packages/grant-explorer/src/features/api/types.ts
@@ -1,4 +1,4 @@
-export type Network = "goerli" | "optimism"
+export type Network = "goerli" | "optimism";
 
 export interface Web3Instance {
   /**
@@ -12,7 +12,7 @@ export interface Web3Instance {
     id: number;
     name: string;
     network: Network;
-  },
+  };
   provider: any;
   signer?: any;
 }
@@ -40,7 +40,7 @@ export interface IPFSObject {
   metadata?: {
     name?: string;
     keyvalues?: object;
-  }
+  };
 }
 
 /** Base Contract interface */
@@ -55,6 +55,17 @@ export interface Contract {
   abi: Array<string>;
 }
 
+// TODO: Document this
+export interface Requirement {
+  requirement?: string;
+}
+
+// TODO: Document this
+export interface Eligibility {
+  description: string;
+  requirements?: Requirement[];
+}
+
 export interface Round {
   /**
    * The on-chain unique round ID
@@ -65,6 +76,8 @@ export interface Round {
    */
   roundMetadata?: {
     name: string;
+    eligibility: Eligibility;
+    programContractAddress: string;
   };
   /**
    * Pointer to round metadata in a decentralized storage e.g IPFS, Ceramic etc.
@@ -130,4 +143,4 @@ export type ProjectMetadata = {
   bannerImg?: string;
   logoImg?: string;
   projectTwitter?: string;
-}
+};

--- a/packages/grant-explorer/src/features/round/__tests__/ViewRoundPage.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/ViewRoundPage.test.tsx
@@ -23,13 +23,49 @@ jest.mock("react-router-dom", () => ({
   useParams: useParamsFn,
 }));
 
-describe("<ViewRound />", () => {
+describe("<ViewRound /> in case of before the round start date", () => {
   let stubRound: Round;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    stubRound = makeRoundData({ id: roundId });
+    const applicationsStartTime = faker.date.recent(); // recent past
+    const applicationsEndTime = faker.date.soon(10, applicationsStartTime);
+    const roundStartTime = faker.date.future(1, applicationsEndTime);
+    const roundEndTime = faker.date.soon(10, roundStartTime);
+    stubRound = makeRoundData({ id: roundId, applicationsStartTime, applicationsEndTime, roundStartTime, roundEndTime });
+  });
+
+  it("should display 404 when round is not found", () => {
+    renderWithContext(<ViewRound />, { rounds: [], isLoading: false });
+    expect(screen.getByText("404 ERROR")).toBeInTheDocument();
+  });
+
+  it("should show the application view page", () => {
+    // render the component
+    renderWithContext(<ViewRound />, { rounds: [stubRound], isLoading: false });
+
+    // expect that components / text / dates / etc. specific to  application view page
+    expect(screen.getByText(stubRound.roundMetadata!.name)).toBeInTheDocument();
+    expect(screen.getByTestId("application-period")).toBeInTheDocument();
+    expect(screen.getByTestId("round-period")).toBeInTheDocument();
+    expect(screen.getByText(stubRound.roundMetadata!.eligibility!.description)).toBeInTheDocument();
+    expect(screen.getByTestId("round-eligibility")).toBeInTheDocument();
+  });
+
+});
+
+describe("<ViewRound /> in case of after the round start date", () => {
+  let stubRound: Round;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const applicationsStartTime = faker.date.past(1); 
+    const applicationsEndTime = faker.date.past(1, applicationsStartTime);
+    const roundStartTime = faker.date.recent();
+    const roundEndTime = faker.date.soon(10, roundStartTime);
+    stubRound = makeRoundData({ id: roundId, applicationsStartTime, applicationsEndTime, roundStartTime, roundEndTime });
   });
 
   it("should display 404 when round is not found", () => {
@@ -126,3 +162,5 @@ describe("<ViewRound />", () => {
     });
   });
 });
+
+

--- a/packages/grant-explorer/src/test-utils.tsx
+++ b/packages/grant-explorer/src/test-utils.tsx
@@ -34,6 +34,8 @@ export const makeRoundData = (overrides: Partial<Round> = {}): Round => {
     id: faker.finance.ethereumAddress(),
     roundMetadata: {
       name: faker.company.name(),
+      eligibility: { description: "name", requirements: [] },
+      programContractAddress: faker.finance.ethereumAddress(),
     },
     store: {
       protocol: 1,


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

As a round operator, I want to configure what the application page will say on Grant Explorer
So that I can tell potential grantees exactly how to get involved in my round.

Todo: 

- [x] GIVEN that I am on Grant Explorer after the round start date then I see the explorer view of the landing page

- [x] GIVEN that I am on Grant Explorer before the round start date then I see the application view page

- [x] GIVEN that I am on the application view page then I see the round eligibility details in the left column

<!-- Describe your changes here. -->

##### Refers/Fixes

fixes #474 
<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
