### PR TITLE
feat: add QF section + payout token #504

### DIFF
--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -5,6 +5,54 @@ export enum ChainId {
   OPTIMISM_MAINNET_CHAIN_ID = 10,
 }
 
+export type PayoutToken = {
+  name: string;
+  chainId: number;
+  address: string;
+  logo?: string;
+  default?: boolean; // TODO: this is only used to provide the initial placeholder item, look for better solution
+};
+
+export const TokenNamesAndLogos: Record<string, string> = {
+  FTM: "https://picsum.photos/256",
+  BUSD: "https://picsum.photos/256",
+  DAI: "https://picsum.photos/256",
+};
+
+// TODO: which tokens should be available on optimism/goerli/other chains?
+//   Also look up real addresses for tokens
+export const getPayoutTokenOptions = (chainId: ChainId): PayoutToken[] => {
+  switch (chainId) {
+    case ChainId.OPTIMISM_MAINNET_CHAIN_ID: {
+      return [
+        {
+          name: "DAI",
+          chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
+          address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          logo: TokenNamesAndLogos["DAI"],
+        },
+      ];
+    }
+    case ChainId.GOERLI_CHAIN_ID:
+    default: {
+      return [
+        {
+          name: "BUSD",
+          chainId: ChainId.GOERLI_CHAIN_ID,
+          address: "0xa7c3bf25ffea8605b516cf878b7435fe1768c89b",
+          logo: TokenNamesAndLogos["BUSD"],
+        },
+        {
+          name: "DAI",
+          chainId: ChainId.GOERLI_CHAIN_ID,
+          address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          logo: TokenNamesAndLogos["DAI"],
+        },
+      ];
+    }
+  }
+};
+
 /**
  * Fetch subgraph network for provided web3 network
  *

--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -3,6 +3,7 @@ import { ApplicationMetadata, InputType, IPFSObject } from "./types";
 export enum ChainId {
   GOERLI_CHAIN_ID = 5,
   OPTIMISM_MAINNET_CHAIN_ID = 10,
+  FANTOM_MAINNET_CHAIN_ID = 250,
 }
 
 export type PayoutToken = {
@@ -17,10 +18,9 @@ export const TokenNamesAndLogos: Record<string, string> = {
   FTM: "https://picsum.photos/256",
   BUSD: "https://picsum.photos/256",
   DAI: "https://picsum.photos/256",
+  ETH: "https://picsum.photos/256",
 };
 
-// TODO: which tokens should be available on optimism/goerli/other chains?
-//   Also look up real addresses for tokens
 export const getPayoutTokenOptions = (chainId: ChainId): PayoutToken[] => {
   switch (chainId) {
     case ChainId.OPTIMISM_MAINNET_CHAIN_ID: {
@@ -29,6 +29,34 @@ export const getPayoutTokenOptions = (chainId: ChainId): PayoutToken[] => {
           name: "DAI",
           chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
           address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          logo: TokenNamesAndLogos["DAI"],
+        },
+        {
+          name: "ETH",
+          chainId: ChainId.OPTIMISM_MAINNET_CHAIN_ID,
+          address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+          logo: TokenNamesAndLogos["ETH"],
+        },
+      ];
+    }
+    case ChainId.FANTOM_MAINNET_CHAIN_ID: {
+      return [
+        {
+          name: "FTM",
+          chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
+          address: "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
+          logo: TokenNamesAndLogos["FTM"],
+        },
+        {
+          name: "BUSD",
+          chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
+          address: "0xC931f61B1534EB21D8c11B24f3f5Ab2471d4aB50",
+          logo: TokenNamesAndLogos["BUSD"],
+        },
+        {
+          name: "DAI",
+          chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
+          address: "0x8D11eC38a3EB5E956B052f67Da8Bdc9bef8Abf3E",
           logo: TokenNamesAndLogos["DAI"],
         },
       ];
@@ -47,6 +75,12 @@ export const getPayoutTokenOptions = (chainId: ChainId): PayoutToken[] => {
           chainId: ChainId.GOERLI_CHAIN_ID,
           address: "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
           logo: TokenNamesAndLogos["DAI"],
+        },
+        {
+          name: "ETH",
+          chainId: ChainId.GOERLI_CHAIN_ID,
+          address: "0x7af963cf6d228e564e2a0aa0ddbf06210b38615d",
+          logo: TokenNamesAndLogos["ETH"],
         },
       ];
     }

--- a/packages/round-manager/src/features/api/utils.ts
+++ b/packages/round-manager/src/features/api/utils.ts
@@ -44,7 +44,7 @@ export const getPayoutTokenOptions = (chainId: ChainId): PayoutToken[] => {
         {
           name: "FTM",
           chainId: ChainId.FANTOM_MAINNET_CHAIN_ID,
-          address: "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
+          address: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
           logo: TokenNamesAndLogos["FTM"],
         },
         {

--- a/packages/round-manager/src/features/round/RoundApplicationForm.tsx
+++ b/packages/round-manager/src/features/round/RoundApplicationForm.tsx
@@ -174,7 +174,6 @@ export function RoundApplicationForm(props: {
       const round = {
         ...data,
         votingStrategy: "0xc76Ea06e2BC6476178e40E2B40bf5C6Bf3c40EF6", // QuadraticFundingVotingStrategy contract
-        token: "0x21C8a148933E6CA502B47D729a485579c22E8A69", // DAI token
         ownedBy: programId,
         operatorWallets: props.initialData.program.operatorWallets,
       } as Round;


### PR DESCRIPTION
##### Description

- [x] add Quadratic Funding Settings section
- [x] add payout token selector
- [x] connect payout token selection with form so that it can be added to the payout contract when deployed
- [x] add validation to make sure user selects a payout token before continuing with the form 

##### Refers/Fixes

fixes #504

