### PR TITLE
fix: revert project registry contract addresses to correct values

### DIFF
--- a/packages/round-manager/src/features/api/contracts.ts
+++ b/packages/round-manager/src/features/api/contracts.ts
@@ -18,12 +18,12 @@ export const projectRegistryContract = (
 
   switch (chainId) {
     case ChainId.OPTIMISM_MAINNET_CHAIN_ID: {
-      address = "";
+      address = "0x8e1bD5Da87C14dd8e08F7ecc2aBf9D1d558ea174";
       break;
     }
     case ChainId.GOERLI_CHAIN_ID:
     default: {
-      address = "0x0fF5962Bc56BA0Cf6D7d6EF90df274AE5dC4D16A";
+      address = "0x832c5391dc7931312CbdBc1046669c9c3A4A28d5";
     }
   }
 


### PR DESCRIPTION
##### Description

The ProjectRegistry contract addresses in `packages/round-manager/src/features/api/contracts.ts` were accidentally overwritten during the contract update changes from #566 

The ProjectRegistry is managed by Grant Hub team, and the addresses have not changed -- the PR returns them to the previous values

For reference, Project Registry deployments are here: https://github.com/gitcoinco/grant-hub/blob/development/client/src/contracts/deployments.ts

##### Refers/Fixes

fixes #576

