### PR TITLE
chore: add nate and melissa to CODEOWNERS. remove shavina and dave

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @thelostone-mc @chibie @shavinac @dschinkel @vacekj @bhargavaparoksham @hmrtn
+*       @thelostone-mc @chibie @vacekj @bhargavaparoksham @hmrtn @nfrgosselin @melissa-neira


### PR DESCRIPTION
As per Oct 27 Retro action item: add Melissa + Nate to default PR reviewer list, so they will automatically be tagged as reviewers for all PRs

Also removing myself and Dave since today is our last day with RM/GE team 😭 