### PR TITLE
add error modal for bulk approve/reject application

### DIFF
--- a/packages/round-manager/src/features/program/CreateProgramPage.tsx
+++ b/packages/round-manager/src/features/program/CreateProgramPage.tsx
@@ -1,7 +1,11 @@
 import { SubmitHandler, useFieldArray, useForm } from "react-hook-form";
 import { NavigateFunction, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { InformationCircleIcon, PlusSmIcon, XIcon } from "@heroicons/react/solid";
+import {
+  InformationCircleIcon,
+  PlusSmIcon,
+  XIcon,
+} from "@heroicons/react/solid";
 
 import { useWallet } from "../common/Auth";
 import { Button, Input } from "../common/styles";
@@ -22,7 +26,6 @@ type FormData = {
 };
 
 export default function CreateProgram() {
-
   datadogLogs.logger.info(`====> Route: /program/create`);
   datadogLogs.logger.info(`====> URL: ${window.location.href}`);
 
@@ -211,23 +214,25 @@ export default function CreateProgram() {
 
                   <div className="sm:basis-1/2">
                     <label htmlFor="program-chain" className="block text-xs">
-                      <span className="opacity-50">
-                        Program Chain
-                      </span>
+                      <span className="opacity-50">Program Chain</span>
                       <ProgramChain />
                     </label>
 
                     <div className="opacity-50 flex mt-1 py-[6px] shadow-sm px-3 border rounded-md border-grey-100">
-                      { CHAINS[chain.id] ?
+                      {CHAINS[chain.id] ? (
                         <>
-                          <img src={CHAINS[chain.id]?.logo} alt="program-chain-logo" className="h-4 w-4 ml-1 mr-2 mt-1"/>
+                          <img
+                            src={CHAINS[chain.id]?.logo}
+                            alt="program-chain-logo"
+                            className="h-4 w-4 ml-1 mr-2 mt-1"
+                          />
                           <p>{chain.name}</p>
                         </>
-                        :
+                      ) : (
                         <>
                           <p>Wrong Network</p>
                         </>
-                      }
+                      )}
                     </div>
                   </div>
                 </div>

--- a/packages/round-manager/src/features/round/ApplicationsApproved.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsApproved.tsx
@@ -94,8 +94,8 @@ export default function ApplicationsApproved() {
       contractUpdatingStatus === ProgressStatus.IS_ERROR
     ) {
       setTimeout(() => {
-        setOpenProgressModal(false);
         setOpenErrorModal(true);
+        setOpenProgressModal(false);
       }, errorModalDelayMs);
     }
 

--- a/packages/round-manager/src/features/round/ApplicationsReceived.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsReceived.tsx
@@ -110,8 +110,8 @@ export default function ApplicationsReceived() {
       contractUpdatingStatus === ProgressStatus.IS_ERROR
     ) {
       setTimeout(() => {
-        setOpenProgressModal(false);
         setOpenErrorModal(true);
+        setOpenProgressModal(false);
       }, errorModalDelayMs);
     }
 

--- a/packages/round-manager/src/features/round/ApplicationsRejected.tsx
+++ b/packages/round-manager/src/features/round/ApplicationsRejected.tsx
@@ -109,8 +109,8 @@ export default function ApplicationsRejected() {
       contractUpdatingStatus === ProgressStatus.IS_ERROR
     ) {
       setTimeout(() => {
-        setOpenProgressModal(false);
         setOpenErrorModal(true);
+        setOpenProgressModal(false);
       }, errorModalDelayMs);
     }
 

--- a/packages/round-manager/src/features/round/BulkApplicationCommon.tsx
+++ b/packages/round-manager/src/features/round/BulkApplicationCommon.tsx
@@ -219,6 +219,7 @@ export function Continue(props: {
           $variant="solid"
           className="text-sm px-5"
           onClick={props.onClick}
+          data-testid="continue-button"
         >
           Continue
         </Button>

--- a/packages/round-manager/src/features/round/ViewApplicationPage.tsx
+++ b/packages/round-manager/src/features/round/ViewApplicationPage.tsx
@@ -132,8 +132,14 @@ export default function ViewApplicationPage() {
     } else if (indexingStatus == ProgressStatus.IS_SUCCESS) {
       redirectToViewRoundPage(navigate, 0, roundId);
     }
-  }, [navigate, IPFSCurrentStatus, contractUpdatingStatus, indexingStatus, id, roundId]);
-
+  }, [
+    navigate,
+    IPFSCurrentStatus,
+    contractUpdatingStatus,
+    indexingStatus,
+    id,
+    roundId,
+  ]);
 
   const { application, isLoading, getApplicationByIdError } =
     useApplicationById(id);
@@ -192,9 +198,7 @@ export default function ViewApplicationPage() {
           },
         ],
       });
-
     } catch (error) {
-
       datadogLogs.logger.error(
         `error: handleReview - ${error}, roundId - ${roundId}`
       );
@@ -537,7 +541,6 @@ function redirectToViewRoundPage(
     navigate(`/round/${id}`);
   }, waitSeconds);
 }
-
 
 function redirectToViewApplicationPage(
   navigate: NavigateFunction,

--- a/packages/round-manager/src/features/round/__tests__/ViewApplicationPage.test.tsx
+++ b/packages/round-manager/src/features/round/__tests__/ViewApplicationPage.test.tsx
@@ -5,7 +5,13 @@ import {
   makeRoundData,
 } from "../../../test-utils";
 import ViewApplicationPage from "../ViewApplicationPage";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { useDisconnect, useSwitchNetwork } from "wagmi";
 import { PassportVerifier } from "@gitcoinco/passport-sdk-verifier";
 import {
@@ -244,10 +250,10 @@ describe("ViewApplicationPage", () => {
       renderWithContext(
         <ViewApplicationPage />,
         {
-          applications: [application]
+          applications: [application],
         },
         {
-          IPFSCurrentStatus: ProgressStatus.IS_ERROR
+          IPFSCurrentStatus: ProgressStatus.IS_ERROR,
         }
       );
 
@@ -257,7 +263,6 @@ describe("ViewApplicationPage", () => {
       fireEvent.click(screen.getByText("Confirm"));
 
       expect(await screen.findByTestId("error-modal")).toBeInTheDocument();
-
     });
 
     it("choosing done closes the error modal", async () => {
@@ -269,10 +274,10 @@ describe("ViewApplicationPage", () => {
       renderWithContext(
         <ViewApplicationPage />,
         {
-          applications: [application]
+          applications: [application],
         },
         {
-          IPFSCurrentStatus: ProgressStatus.IS_ERROR
+          IPFSCurrentStatus: ProgressStatus.IS_ERROR,
         }
       );
 
@@ -281,7 +286,7 @@ describe("ViewApplicationPage", () => {
       await screen.findByTestId("confirm-modal");
       fireEvent.click(screen.getByText("Confirm"));
 
-      await screen.findByTestId("error-modal")
+      await screen.findByTestId("error-modal");
 
       const done = await screen.findByTestId("done");
       await act(() => {
@@ -300,10 +305,10 @@ describe("ViewApplicationPage", () => {
       renderWithContext(
         <ViewApplicationPage />,
         {
-          applications: [application]
+          applications: [application],
         },
         {
-          IPFSCurrentStatus: ProgressStatus.IS_ERROR
+          IPFSCurrentStatus: ProgressStatus.IS_ERROR,
         }
       );
 
@@ -620,7 +625,7 @@ export const renderWithContext = (
       <BulkUpdateGrantApplicationContext.Provider
         value={{
           ...initialBulkUpdateGrantApplicationState,
-          ...bulkUpdateGrantApplicationStateOverrides
+          ...bulkUpdateGrantApplicationStateOverrides,
         }}
       >
         <RoundContext.Provider


### PR DESCRIPTION

##### Description

when there is an error during the approve/reject flow, the error modal should appear with "Try Again" or "Done" options. this is the same error modal that appears during round creation and program creation flows

##### Refers/Fixes

fixes #593
