### PR TITLE
feat: enable optimism mainnet support

### DIFF
--- a/packages/contracts/docs/CHAINS.md
+++ b/packages/contracts/docs/CHAINS.md
@@ -2,9 +2,35 @@
 
 This document lists all the addresses of the contracts that have been deployed on a given network
 
+
+## Optimism Mainnet
+
+These are contracts are created/deployed once for optimism mainnet
+
+| Contract                              | Address                                    |
+|---------------------------------------|--------------------------------------------|
+| ProgramFactory                        | 0x8918401DD47f1645fF1111D8E513c0404b84d5bB |
+| ProgramImplementation                 | 0x809E751e5C5bB1446e9ab2Ac37c687a35DE53BC6 |
+| QuadraticFundingVotingStrategyFactory | 0xE1F4A28299966686c689223Ee7803258Dbde0942 |
+| QFVotingStrategyImplementation        | 0x5987A30F7Cb138c231de96Fe1522Fe4f1e83940D |
+| RoundFactory                          | 0x0f0A4961274A578443089D06AfB9d1fC231A5a4D |
+| RoundImplementation                   | 0xCd5AbD09ee34BA604795F7f69413caf20ee0Ab60 |
+
+
+**Sample contracts unique to a round **
+
+These are contracts are created/deployed for every round created on optimism mainnet
+
+| Contract                              | Address                                    |
+|---------------------------------------|--------------------------------------------|
+| Program                               | 0x228907B3b4C4877885320654b98465daF62C3766 |
+| QFVotingContract                      | 0x2D3Abb193d5118A2F96004A9316830d9E96f44Aa |
+| MerklePayoutContract                  | 0x835A581472Ce6a1f1108d9484567a2162C9959C8 |
+| Round                                 | 0xe0883e6F3113FC4C2d9539b9eE1659E59531e312 |
+
 ## Fantom Mainnet
 
-These are contracts are created/deployed once for fantom testnet
+These are contracts are created/deployed once for fantom mainnet
 
 | Contract                              | Address                                    |
 |---------------------------------------|--------------------------------------------|
@@ -18,13 +44,13 @@ These are contracts are created/deployed once for fantom testnet
 
 **Sample contracts unique to a round **
 
-These are contracts are created/deployed for every round created on fantom testnet
+These are contracts are created/deployed for every round created on fantom mainnet
 
 | Contract                              | Address                                    |
 |---------------------------------------|--------------------------------------------|
 | Program                               | 0x4fde273e009F58Aa0e5e09289242D5336FD18ad1 |
 | QFVotingContract                      | 0x818A3C8F82667bd222faF84a954F35d2b0Eb6a78 |
-| MerklePayoutContract                  | 0xB5CF3fFD3BDfC6A124aa9dD96fE14118Ed8083e5 | 
+| MerklePayoutContract                  | 0xB5CF3fFD3BDfC6A124aa9dD96fE14118Ed8083e5 |
 | Round                                 | 0x866485759ABC95c36FA77B216A5AdbA4275a14aB |
 
 ## Goerli Network
@@ -75,5 +101,5 @@ These are contracts are created/deployed for every round created on fantom testn
 |---------------------------------------|--------------------------------------------|
 | Program                               | 0x3Cd6edA7fDF9ab6b6AF6E226Ce184569C5DF8Ae5 |
 | QFVotingContract                      | 0x02B52C3a398567AdFffb3396d6eE3d3c2bff37fE |
-| MerklePayoutContract                  | 0xcaC94621584a1a0121c0B5664A9FFB0B86588B8a | 
+| MerklePayoutContract                  | 0xcaC94621584a1a0121c0B5664A9FFB0B86588B8a |
 | Round                                 | 0xd3E45c78050a6472e28b9E02AA8596F7868e63d6 |

--- a/packages/contracts/scripts/config/payoutStrategy.config.ts
+++ b/packages/contracts/scripts/config/payoutStrategy.config.ts
@@ -10,7 +10,7 @@ export const PayoutParams: DeployParams = {
     merklePayoutContract: '0x4A68275B53165d9209Ec3f535a331A3f0160d6FF'
   },
   "optimism-mainnet": {
-    merklePayoutContract: ''
+    merklePayoutContract: '0x835A581472Ce6a1f1108d9484567a2162C9959C8'
   },
   "fantom-mainnet": {
     merklePayoutContract: '0xB5CF3fFD3BDfC6A124aa9dD96fE14118Ed8083e5'

--- a/packages/contracts/scripts/config/program.config.ts
+++ b/packages/contracts/scripts/config/program.config.ts
@@ -14,9 +14,9 @@ export const programParams: DeployParams = {
     programContract: '0x86DceaCc03A52b7914b72eB4E10290f72BD99e68'
   },
   "optimism-mainnet": {
-    programFactoryContract: '',
-    programImplementationContract: '',
-    programContract: ''
+    programFactoryContract: '0x8918401DD47f1645fF1111D8E513c0404b84d5bB',
+    programImplementationContract: '0x809E751e5C5bB1446e9ab2Ac37c687a35DE53BC6',
+    programContract: '0x228907B3b4C4877885320654b98465daF62C3766'
   },
   "fantom-mainnet": {
     programFactoryContract: '0xe0281a20dFaCb0E179E6581c33542bC533DdC4AB',

--- a/packages/contracts/scripts/config/round.config.ts
+++ b/packages/contracts/scripts/config/round.config.ts
@@ -14,9 +14,9 @@ export const roundParams: DeployParams = {
     roundContract: '0xcEF1772Dd6764C95f14c26B25e8f012C072C5F77'
   },
   "optimism-mainnet": {
-    roundFactoryContract: '',
-    roundImplementationContract: '',
-    roundContract: ''
+    roundFactoryContract: '0x0f0A4961274A578443089D06AfB9d1fC231A5a4D',
+    roundImplementationContract: '0xCd5AbD09ee34BA604795F7f69413caf20ee0Ab60',
+    roundContract: '0xe0883e6F3113FC4C2d9539b9eE1659E59531e312'
   },
   "fantom-mainnet": {
     roundFactoryContract: '0x3e7f72DFeDF6ba1BcBFE77A94a752C529Bb4429E',

--- a/packages/contracts/scripts/config/votingStrategy.config.ts
+++ b/packages/contracts/scripts/config/votingStrategy.config.ts
@@ -14,9 +14,9 @@ export const QFVotingParams: DeployParams = {
     contract: '0x1a497D28890EfB320D04F534Fa6318B6A0657619'
   },
   "optimism-mainnet": {
-    factory: '',
-    implementation: '',
-    contract: ''
+    factory: '0xE1F4A28299966686c689223Ee7803258Dbde0942',
+    implementation: '0x5987A30F7Cb138c231de96Fe1522Fe4f1e83940D',
+    contract: '0x2D3Abb193d5118A2F96004A9316830d9E96f44Aa'
   },
   "fantom-mainnet": {
     factory: '0x06A6Cc566c5A88E77B1353Cdc3110C2e6c828e38',

--- a/packages/grant-explorer/src/app/wagmi.ts
+++ b/packages/grant-explorer/src/app/wagmi.ts
@@ -72,7 +72,7 @@ const mainnetChains = () => {
   };
 
   return [
-    // chain.optimism,
+    chain.optimism,
     fantomMainnet
   ];
 }

--- a/packages/graph/config/optimism.json
+++ b/packages/graph/config/optimism.json
@@ -1,7 +1,7 @@
 {
   "network": "optimism",
-  "startBlock": 21463380,
-  "programFactoryAddress": "",
-  "QFVotingStrategyFactoryAddress": "",
-  "roundFactoryAddress": ""
+  "startBlock": 37889940,
+  "programFactoryAddress": "0x8918401DD47f1645fF1111D8E513c0404b84d5bB",
+  "QFVotingStrategyFactoryAddress": "0xE1F4A28299966686c689223Ee7803258Dbde0942",
+  "roundFactoryAddress": "0x0f0A4961274A578443089D06AfB9d1fC231A5a4D"
 }

--- a/packages/round-manager/src/app/wagmi.ts
+++ b/packages/round-manager/src/app/wagmi.ts
@@ -68,7 +68,7 @@ const mainnetChains = () => {
   };
 
   return [
-    // chain.optimism,
+    chain.optimism,
     fantomMainnet,
   ];
 };

--- a/packages/round-manager/src/features/api/contracts.ts
+++ b/packages/round-manager/src/features/api/contracts.ts
@@ -54,7 +54,7 @@ export const programFactoryContract = (
 
   switch (chainId) {
     case ChainId.OPTIMISM_MAINNET_CHAIN_ID: {
-      address = "";
+      address = "0x8918401DD47f1645fF1111D8E513c0404b84d5bB";
       break;
     }
     case ChainId.FANTOM_MAINNET_CHAIN_ID: {
@@ -95,7 +95,7 @@ export const roundFactoryContract = (
 
   switch (chainId) {
     case ChainId.OPTIMISM_MAINNET_CHAIN_ID: {
-      address = "";
+      address = "0x0f0A4961274A578443089D06AfB9d1fC231A5a4D";
       break;
     }
     case ChainId.FANTOM_MAINNET_CHAIN_ID: {
@@ -136,7 +136,7 @@ export const qfVotingStrategyFactoryContract = (
 
   switch (chainId) {
     case ChainId.OPTIMISM_MAINNET_CHAIN_ID: {
-      address = "";
+      address = "0xE1F4A28299966686c689223Ee7803258Dbde0942";
       break;
     }
     case ChainId.FANTOM_MAINNET_CHAIN_ID: {


### PR DESCRIPTION
##### Description

- deploy contracts
- update round manger + grant explorer to support optimism mainnet
- deploy subgraph for optimism mainnet




<!-- Describe your changes here. -->

##### Refers/Fixes

fixes #662

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

- #/program/0x228907b3b4c4877885320654b98465daf62c3766
- #/round/0xe0883e6f3113fc4c2d9539b9ee1659e59531e312
- https://thegraph.com/hosted-service/subgraph/gitcoinco/grants-round-optimism-mainnet
