### PR TITLE
feat(githooks): fix yarn warning re: --

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,5 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # treat warnings as errors to prevent the build passing locally, but failing on CI
-yarn lerna run --scope=round-manager lint:fix -- -- --max-warnings=0
+lerna run --scope=round-manager lint:fix -- --max-warnings=0
 yarn run test


### PR DESCRIPTION
**Note: only relevant for Engineering.**

Yarn printed a warning regarding the passing of -- to the underlying scripts. Removed the -- and removed the yarn prefix to fix this.

Tested locally on latest macOS Ventura ARM Mac
