### PR TITLE
fix(re): fix for new id format

### DIFF
--- a/packages/round-manager/src/features/api/application.ts
+++ b/packages/round-manager/src/features/api/application.ts
@@ -217,9 +217,11 @@ const fetchApplicationData = async (
 
       const projectMetadata = application.project;
       const projectRegistryId = projectMetadata.id;
-      const projectOwners = await projectRegistry.getProjectOwners(
-        projectRegistryId
-      );
+      const fixedId = projectRegistryId.includes(":")
+        ? projectRegistryId.split(":")[2]
+        : projectRegistryId;
+
+      const projectOwners = await projectRegistry.getProjectOwners(fixedId);
       const grantApplicationProjectMetadata: Project = {
         ...projectMetadata,
         owners: projectOwners.map((address: string) => ({ address })),


### PR DESCRIPTION
Grants Hub changed the id format from "projectId" to "chainId:projectRegistryAddress:projectId". This PR adds support for this new format. closes #733 

https://discord.com/channels/562828676480237578/1048235936691007519/1048320321419214899