### PR TITLE
add: Project/Round summary endpoints

### DIFF
--- a/packages/api/src/handlers/summaryHandler.ts
+++ b/packages/api/src/handlers/summaryHandler.ts
@@ -1,0 +1,172 @@
+import { ChainId, ProjectSummary, QFContribution } from "../types";
+import { fetchFromGraphQL, fetchRoundMetadata, handleResponse } from "../utils";
+import {
+  fetchStatsHandler as linearQFFetchRoundStats,
+  fetchVotesForRoundHandler as linearQFFetchVotesForRound
+} from "../votingStrategies/linearQuadraticFunding";
+import {Request, Response} from "express";
+
+export const summaryHandler = async (req: Request, res: Response) => {
+  const { chainId, roundId } = req.params;
+  const { projectId } = req.query;
+
+  if (!chainId || !roundId) {
+    handleResponse(res, 400, "error: missing parameter chainId or roundId");
+  }
+  if (projectId) {
+    const projectIds: string[] = projectId.toString().split(",");
+
+    // fetch project summaries
+    try {
+      const results = await getProjectsSummary(chainId as ChainId, roundId, projectIds);
+      return handleResponse(res, 200, "fetched project in round stats successfully", results);
+    } catch (err) {
+      return handleResponse(res, 500, "error: something went wrong.");
+    }
+
+  } else {
+    // fetch round stats
+    try {
+      const results = await getRoundSummary(chainId as ChainId, roundId);
+      console.log("here");
+      return handleResponse(res, 200, "fetched round stats successfully", results);
+    } catch (err) {
+      return handleResponse(res, 500, "error: something went wrong", err);
+    }
+  }
+}
+
+export const getRoundSummary = async (chainId: ChainId, roundId: string): Promise<any> => {
+  let results;
+
+  // fetch metadata
+  const metadata = await fetchRoundMetadata(chainId, roundId);
+
+  const { id: votingStrategyId, strategyName } = metadata.votingStrategy;
+
+  // handle how stats should be derived per voting strategy
+  switch (strategyName) {
+    case "LINEAR_QUADRATIC_FUNDING":
+      // fetch votes
+      const votes = await linearQFFetchVotesForRound(chainId, votingStrategyId);
+      // fetch round stats
+      results =  await linearQFFetchRoundStats(chainId, votes, metadata);
+      break;
+    default:
+      throw("error: unsupported voting strategy");
+  }
+
+  return results;
+}
+
+export const getProjectsSummary = async (chainId: ChainId, roundId: string, projectIds: string[]): Promise<any> => {
+  let results: any = [];
+  // fetch metadata
+  const metadata = await fetchRoundMetadata(chainId, roundId);
+  // console.log(metadata)
+  const { id: votingStrategyId, strategyName } = metadata.votingStrategy;
+  // handle how stats should be derived per voting strategy
+  switch (strategyName) {
+    case "LINEAR_QUADRATIC_FUNDING":
+      // fetch votes
+      const votes = await fetchVotesForProjects(chainId, votingStrategyId, projectIds);
+      // fetch round stats
+      results =  await summarizeProjects(chainId, votes);
+      break;
+    default:
+      throw("error: unsupported voting strategy");
+  }
+
+  return results;
+}
+
+export const summarizeProjects = async (
+  chainId: ChainId,
+  contributions: QFContribution[],
+): Promise<ProjectSummary> => {
+
+  // Create an object to store the sums
+  const summary: any = {};
+
+  // Iterate over the array of objects
+  contributions.forEach((item: QFContribution) => {
+    // Get the project ID and token
+    const projectId = item.projectId;
+    const token = item.token;
+    const contributor = item.contributor;
+
+
+    // Initialize the object for the project ID if it doesn't exist
+    if (!summary[projectId]) {
+      summary[projectId] = {} as ProjectSummary;
+      summary[projectId].contributions = {};
+      summary[projectId].contributors = [];
+    }
+
+    // Initialize the sum for the token if it doesn't exist
+    if (!summary[projectId].contributions[token]) {
+      summary[projectId].contributions[token] = 0;
+    }
+    // Initialize the contributor if it doesn't exist
+    if (!summary[projectId].contributors.includes(contributor)) {
+      summary[projectId].contributors.push(contributor);
+    }
+
+    // Update the sum for the token
+    summary[projectId].contributions[token] += item.amount;
+
+  });
+
+  // Return the sums object
+  return summary;
+}
+
+export const fetchVotesForProjects = async (
+  chainId: ChainId,
+  votingStrategyId: string,
+  projectIds: string[]
+): Promise<QFContribution[]> => {
+  const variables = { votingStrategyId, projectIds };
+
+  // query and filter votes for a project by id
+  const query = `
+      query GetVotesForProjectsInRound($votingStrategyId: String, $projectIds: [String!]) {
+      votingStrategies(where: {
+        id: $votingStrategyId
+      }) {
+        votes(where: {
+          to_in: $projectIds
+        }) {
+          votingStrategy 
+          amount
+          token
+          from
+          to
+        }
+      }
+    }
+    `;
+
+  // fetch from graphql
+  const response = await fetchFromGraphQL(chainId, query, variables);
+
+  const votes = response.data?.votingStrategies[0]?.votes;
+
+  let contributions: QFContribution[] = [];
+
+  votes.map((vote: any) => {
+    const contribution = {
+      projectId: vote.to, // TODO: we will have to update this to project id eventually
+      contributor: vote.from,
+      amount: Number(vote.amount),
+      token: vote.token,
+    } as QFContribution;
+
+    contributions.push(contribution);
+  });
+
+  return contributions;
+};
+
+
+

--- a/packages/api/src/routes.ts
+++ b/packages/api/src/routes.ts
@@ -1,9 +1,13 @@
-import { Router, Request, Response } from "express";
-import { calculateHandler } from "./handlers/calculateHandler";
-import { fetchMatchingHandler } from "./handlers/fetchMatchingHandler";
-import { convertPriceHandler } from "./handlers/convertPriceHandler";
-import { fetchRoundStatsHandler } from "./handlers/fetchRoundStatsHandler";
-import { fetchProjectInRoundStatsHandler } from "./handlers/fetchProjectInRoundStatsHandler";
+import {Request, Response, Router} from "express";
+import {calculateHandler} from "./handlers/calculateHandler";
+import {fetchMatchingHandler} from "./handlers/fetchMatchingHandler";
+import {convertPriceHandler} from "./handlers/convertPriceHandler";
+import {fetchRoundStatsHandler} from "./handlers/fetchRoundStatsHandler";
+import {
+  fetchProjectInRoundStatsHandler,
+} from "./handlers/fetchProjectInRoundStatsHandler";
+import {summaryHandler} from "./handlers/summaryHandler";
+
 
 const router = Router();
 
@@ -19,6 +23,8 @@ router.post("/convert-price", convertPriceHandler);
 
 router.get("/round-stats", fetchRoundStatsHandler); 
 
-router.get("/project-stats", fetchProjectInRoundStatsHandler); 
+router.get("/project-stats", fetchProjectInRoundStatsHandler);
+
+router.get("/summary/:chainId/:roundId", summaryHandler);
 
 export default router;

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -45,6 +45,11 @@ export type RoundStats = {
   totalContributionsInUSD: number;
 }
 
+export type ProjectSummary = {
+  contributors: string[];
+  contributions: [];
+}
+
 export type HandleResponseObject = {
   success: boolean;
   message: string;

--- a/packages/api/src/votingStrategies/linearQuadraticFunding.ts
+++ b/packages/api/src/votingStrategies/linearQuadraticFunding.ts
@@ -106,7 +106,7 @@ export const fetchVotesForProjectInRoundHandler = async (
 
   // TODO: UPDATE LINE 83 from to -> projectId after upgrading subgraph
   const query = `
-    query GetVotesForProjectInRound($votingStrategyId: String, projectId: String) {
+    query GetVotesForProjectInRound($votingStrategyId: String, $projectId: String) {
       votingStrategies(where: {
         id: $votingStrategyId
       }) {


### PR DESCRIPTION
This is a refactoring of the endpoints in the API. 

Instead of having a bunch of separate handlers for specific endpoints and usage, this introduces a single endpoint for project and round summaries.

This does not remove any existing endpoints, they should be deprecated as tests and implementations are refactored with the new endpoint. 

The endpoint is `/summary/:chainId/:roundId` and making a GET request with to this endpoint will yield a summary of the round: 
```
GET http://localhost:8000/summary/250/0xebdb4156203c8b35b7a7c6f320786b98e5ac67c3
```
```
{
    "success": true,
    "message": "fetched round stats successfully",
    "data": {
        "uniqueContributorCount": 60,
        "contributionsCount": 100,
        "totalContributionsInUSD": 0
    }
}
```
Furthermore, you can also use this endpoint to get project summaries, one or many at a time, with project id query parameters:
```
GET http://localhost:8000/summary/250/0xebdb4156203c8b35b7a7c6f320786b98e5ac67c3?projectId=0x4e260bb2b25ec6f3a59b478fcde5ed5b8d783b02,0x8230d08fd17cab204f91a549b03c94f401549418
```
```
{
    "success": true,
    "message": "fetched project in round stats successfully",
    "data": {
        "0x8230d08fd17cab204f91a549b03c94f401549418": {
            "contributions": {
                "0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83": 2.0005e+21,
                "0x0000000000000000000000000000000000000000": 77624000000000000000,
                "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e": 22000000000000000000
            },
            "contributors": [
                "0x3a37c297dcb086f1aeb32fc5219ba9fc2792a333",
                                  ...
                "0x45b61fd52c567001111e004371cc3e7559ed569f"
            ]
        },
        "0x4e260bb2b25ec6f3a59b478fcde5ed5b8d783b02": {
            "contributions": {
                "0x0000000000000000000000000000000000000000": 181574000000000000000,
                "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e": 3000000000000000000,
                "0x21be370d5312f44cb42ce377bc9b8a0cef1a4c83": 5500000000000000000
            },
            "contributors": [
                "0x917fe0cec2cc73098abd2a9fc3dcba26f4fdd911",
                                 ...
                "0x94bf625a16e696cbb6ac776d498435782b37af88"
            ]
        }
    }
}
```

We can modify the summaries as needed. 

This also addresses issue 2 on issue #836 by adding the missing `$` to the graph query.

This endpoint can be used for issue #482, issue #770, etc.

Todo: 
- [ ] Replace existing usage of endpoints with new format like `summaryHandler`
- [ ] Tests and test refactoring
- [ ] `all` project id query param to get all the project summaries in a round
- [ ] 