### PR TITLE
Tagmanager url fragment fix

### DIFF
--- a/packages/grant-explorer/package.json
+++ b/packages/grant-explorer/package.json
@@ -43,7 +43,7 @@
     "react": "^18.1.0",
     "react-datetime": "^3.1.1",
     "react-dom": "^18.1.0",
-    "react-gtm-module": "^2.0.11",
+    "react-ga4": "^1.4.1",
     "react-hook-form": "^7.31.3",
     "react-redux": "^8.0.1",
     "react-router-dom": "6",

--- a/packages/grant-explorer/src/index.tsx
+++ b/packages/grant-explorer/src/index.tsx
@@ -8,7 +8,7 @@ import { WagmiConfig } from "wagmi";
 import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { initDatadog } from "./datadog";
 import { initSentry } from "./sentry";
-import TagManager from "react-gtm-module";
+import { initTagmanager } from "./tagmanager";
 
 import { store } from "./app/store";
 import { chains, client as WagmiClient } from "./app/wagmi";
@@ -34,16 +34,8 @@ initSentry();
 // Initialize datadog
 initDatadog();
 
-// Intialize TagManager
-if (process.env.REACT_APP_TAG_MANAGER) {
-  TagManager.initialize({
-    gtmId: `${process.env.REACT_APP_TAG_MANAGER}`,
-    events: {
-      "gtm.start": new Date().getTime(),
-      "event": "gtm.js"
-    }
-  });
-}
+// Initialize tagmanager
+initTagmanager();
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -87,7 +79,7 @@ root.render(
                     path="/round/:chainId/:roundId/:txHash/thankyou"
                     element={
                       <QFDonationProvider>
-                        <ThankYou/>
+                        <ThankYou />
                       </QFDonationProvider>
                     }
                   />

--- a/packages/grant-explorer/src/tagmanager.ts
+++ b/packages/grant-explorer/src/tagmanager.ts
@@ -1,0 +1,7 @@
+import ReactGA from "react-ga4";
+
+export const initTagmanager = () => {
+  if (process.env.REACT_APP_TAG_MANAGER) {
+    ReactGA.initialize(`${process.env.REACT_APP_TAG_MANAGER}`);
+  }
+};

--- a/packages/grant-explorer/yarn.lock
+++ b/packages/grant-explorer/yarn.lock
@@ -11569,10 +11569,10 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-gtm-module@^2.0.11:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
-  integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
+react-ga4@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-1.4.1.tgz#6ee2a2db115ed235b2f2092bc746b4eeeca9e206"
+  integrity sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w==
 
 react-hook-form@^7.31.3:
   version "7.31.3"

--- a/packages/round-manager/package.json
+++ b/packages/round-manager/package.json
@@ -42,7 +42,7 @@
     "react": "^18.1.0",
     "react-datetime": "^3.1.1",
     "react-dom": "^18.1.0",
-    "react-gtm-module": "^2.0.11",
+    "react-ga4": "^1.4.1",
     "react-hook-form": "^7.31.3",
     "react-redux": "^8.0.1",
     "react-router-dom": "6",

--- a/packages/round-manager/src/index.tsx
+++ b/packages/round-manager/src/index.tsx
@@ -6,7 +6,7 @@ import { Route, Routes } from "react-router-dom";
 import { WagmiConfig } from "wagmi";
 import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { initDatadog } from "./datadog";
-import TagManager from "react-gtm-module";
+import { initTagmanager } from "./tagmanager";
 
 import { store } from "./app/store";
 import { chains, client as WagmiClient } from "./app/wagmi";
@@ -39,16 +39,8 @@ initSentry();
 // Initialize datadog
 initDatadog();
 
-// Intialize TagManager
-if (process.env.REACT_APP_TAG_MANAGER) {
-  TagManager.initialize({
-    gtmId: `${process.env.REACT_APP_TAG_MANAGER}`,
-    events: {
-      "gtm.start": new Date().getTime(),
-      event: "gtm.js",
-    },
-  });
-}
+// Initialize tagmanager
+initTagmanager();
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement

--- a/packages/round-manager/src/tagmanager.ts
+++ b/packages/round-manager/src/tagmanager.ts
@@ -1,0 +1,7 @@
+import ReactGA from "react-ga4";
+
+export const initTagmanager = () => {
+  if (process.env.REACT_APP_TAG_MANAGER) {
+    ReactGA.initialize(`${process.env.REACT_APP_TAG_MANAGER}`);
+  }
+};

--- a/packages/round-manager/yarn.lock
+++ b/packages/round-manager/yarn.lock
@@ -10233,10 +10233,10 @@ react-error-overlay@^6.0.11:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
   integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
 
-react-gtm-module@^2.0.11:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/react-gtm-module/-/react-gtm-module-2.0.11.tgz#14484dac8257acd93614e347c32da9c5ac524206"
-  integrity sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==
+react-ga4@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-1.4.1.tgz#6ee2a2db115ed235b2f2092bc746b4eeeca9e206"
+  integrity sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w==
 
 react-hook-form@^7.31.3:
   version "7.34.2"


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

The react-gtm-module doesn't appear to log the URL fragments, so switch over to react-ga4 to see if it solves the issue.  This module appears to be more focussed on support for Google Analytics 4.

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

Difficult to test this as it's using an external service.