### PR TITLE
fix: query first 1000

### DIFF
--- a/packages/round-manager/src/features/api/application.ts
+++ b/packages/round-manager/src/features/api/application.ts
@@ -119,7 +119,8 @@ export const getApplicationsByRoundId = async (
         // (status ? `status: $status` : ``)
         // +
         `
-          }) {
+          }
+          first: 1000) {
             id
             metaPtr {
               protocol


### PR DESCRIPTION
due to graphs limit of 100 results, not all projects are shown in round manager. to fix this, the limit is set to 1000