### PR TITLE
feat: wire in passport

### DIFF
--- a/packages/api/.env.sample
+++ b/packages/api/.env.sample
@@ -21,3 +21,6 @@ SENTRY_DSN=####
 
 # Etherscan API key
 OPTIMISM_ETHERSCAN_API=####
+
+# Passport API key
+PASSPORT_API_KEY=####

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,7 @@
     "node": ">=16.15.0"
   },
   "scripts": {
-    "test": "jest --setupFiles dotenv/config",
+    "test": "jest",
     "build": "npx tsc",
     "start": "node bin/index.js",
     "start:dev": "nodemon bin/index.js",

--- a/packages/api/src/sybilProtection/__tests__/passport.test.ts
+++ b/packages/api/src/sybilProtection/__tests__/passport.test.ts
@@ -1,0 +1,169 @@
+import { enableFetchMocks, FetchMock } from "jest-fetch-mock";
+enableFetchMocks();
+const fetchMock = fetch as FetchMock;
+
+import {
+  mockPassportAboveThreshold,
+  mockPassportBelowThreshold
+} from "../../test-utils";
+
+import {
+  fetchContributorsAboveThreshold,
+  fetchPassportScores,
+  filterPassportByEvidence
+} from "../passport";
+
+import * as passport from "../passport";
+
+describe("passport", () => {
+
+  describe("fetchPassportScores", () => {
+    beforeEach(() => {
+      fetchMock.resetMocks();
+    });
+
+    it("SHOULD call fetch WHEN invoked with query parameters", async () => {
+
+      const passports = [mockPassportAboveThreshold(), mockPassportBelowThreshold()]
+
+      fetchMock.mockResponseOnce(JSON.stringify({
+        count: passports.length,
+        items: passports
+      }));
+
+      const communityId = 13;
+      const offset = 100;
+      const limit = 100;
+
+      await fetchPassportScores(communityId, limit, offset);
+
+      expect(fetchMock).toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://api.scorer.gitcoin.co/registry/score/${communityId}?limit=${limit}&offset=${offset}`,
+        {"headers": {"Authorization": `Bearer ${process.env.PASSPORT_API_KEY}`, "Content-Type": "application/json"}, "method": "GET"}
+      )
+    });
+  });
+
+  describe("filterPassportByEvidence", () => {
+
+    beforeEach(() => {
+      fetchMock.resetMocks();
+    });
+
+    it("SHOULD return empty array WHEN all passport are below threshold", () => {
+      const passports = [
+        mockPassportBelowThreshold(),
+        mockPassportBelowThreshold()
+      ];
+
+      const passportsAboveThreshold = filterPassportByEvidence(passports);
+
+      expect(passportsAboveThreshold.length).toEqual(0);
+    });
+
+    it("SHOULD filter passport scores above threshold", () => {
+      const passports = [
+        mockPassportAboveThreshold(),
+        mockPassportBelowThreshold()
+      ];
+
+      const passportsAboveThreshold = filterPassportByEvidence(passports);
+
+      expect(passportsAboveThreshold.length).toEqual(1);
+      expect(passportsAboveThreshold[0]).toEqual(passports[0]);
+    })
+  });
+
+  describe("fetchContributorsAboveThreshold", () => {
+
+    jest.mock("../passport");
+
+    const count = 1000;
+
+    beforeEach(() => {
+      fetchMock.resetMocks();
+      jest.clearAllMocks();
+    });
+
+    it("SHOULD return empty array WHEN all passports are below threshold", async() => {
+
+      const passports = [
+        mockPassportBelowThreshold(),
+        mockPassportBelowThreshold(),
+        mockPassportBelowThreshold()
+      ];
+
+      fetchMock.mockResponseOnce(JSON.stringify({
+        items: passports,
+        count: count
+      }));
+
+      jest
+      .spyOn(passport, "fetchPassportScores")
+      .mockResolvedValueOnce({
+        passports,
+        count
+      });
+
+      const contributors = await fetchContributorsAboveThreshold();
+      expect(contributors.length).toEqual(0);
+    });
+
+    it("SHOULD return array of addresses WHOSE passports are above threshold", async() => {
+      const passports = [
+        mockPassportAboveThreshold(),
+        mockPassportAboveThreshold(),
+        mockPassportBelowThreshold()
+      ];
+
+      fetchMock.mockResponseOnce(JSON.stringify({
+        items: passports,
+        count: count
+      }));
+
+      jest
+      .spyOn(passport, "fetchPassportScores")
+      .mockResolvedValueOnce({
+        passports,
+        count
+      });
+
+      const contributors = await fetchContributorsAboveThreshold();
+
+      expect(contributors.length).toEqual(2);
+      expect(contributors[0].toLowerCase()).toEqual(passports[0].address?.toLowerCase());
+      expect(contributors[1].toLocaleLowerCase()).toEqual(passports[1].address?.toLowerCase());
+    });
+
+
+    it("SHOULD invoke fetchPassportScores N times WHEN pagination count is N", async() => {
+
+      const paginationCount = 3;
+
+      const passports = [
+        mockPassportAboveThreshold(),
+        mockPassportAboveThreshold(),
+        mockPassportBelowThreshold()
+      ];
+
+      fetchMock.mockResponseOnce(JSON.stringify({
+        items: passports,
+        count: count
+      }));
+
+      jest
+      .spyOn(passport, "fetchPassportScores")
+      .mockResolvedValue({
+        passports,
+        count : count * paginationCount
+      });
+
+      await fetchContributorsAboveThreshold();
+
+      expect(fetchPassportScores).toBeCalledTimes(paginationCount);
+
+    });
+
+  });
+})

--- a/packages/api/src/sybilProtection/passport.ts
+++ b/packages/api/src/sybilProtection/passport.ts
@@ -1,0 +1,98 @@
+import { ethers } from "ethers";
+import  { PassportResponse } from "../types";
+import fetch from "node-fetch";
+
+type PassportScoresResponse = {
+  count: number,
+  passports: PassportResponse[]
+}
+
+/**
+ * Fetches list of contributors who have score above the threshold
+ * as reported by the ThresholdScoreCheck from passport scorer
+ *
+ * @returns string[]
+ */
+export const fetchContributorsAboveThreshold = async () => {
+
+  const communityId = 13;
+  const limit = 1000;
+  let offset = 0;
+
+  let allPassports: PassportResponse[];
+
+  let { passports, count } = await fetchPassportScores(
+    communityId, limit, offset
+  );
+
+  allPassports = passports;
+
+  const paginationCount = count / limit;
+
+  for (let i = 1; i < paginationCount; i++) {
+    // increase offset
+    offset += limit;
+
+    // fetch next set of passports
+    const { passports } = await fetchPassportScores(
+      communityId, limit, offset
+    );
+
+    allPassports.push(...passports);
+  }
+
+  const passportAboveThreshold = filterPassportByEvidence(allPassports);
+
+  let contributorsAboveThreshold: string[] = [];
+  passportAboveThreshold.map(passport => {
+    const checksumAddress = ethers.utils.getAddress(passport.address!);
+    contributorsAboveThreshold.push(checksumAddress);
+  });
+
+  return contributorsAboveThreshold;
+}
+
+/**
+ * Filters passports having evidence.success as true
+ *
+ * @param passports PassportResponse[]
+ * @returns PassportResponse[]
+ */
+export const filterPassportByEvidence = (passports: PassportResponse[]): PassportResponse[] => {
+  return passports.filter(passport => passport.evidence && passport.evidence.success)
+}
+
+/**
+ * Fetches passport scores of a given community based on limit and offset
+ *
+ * @param communityId number
+ * @param limit number
+ * @param offset number
+ * @returns Promise<PassportScoresResponse>
+ */
+export const fetchPassportScores = async (
+  communityId: number,
+  limit: number,
+  offset: number
+): Promise<PassportScoresResponse> => {
+
+  const passportURL = `https://api.scorer.gitcoin.co/registry/score/${communityId}?limit=${limit}&offset=${offset}`;
+
+  const response = await fetch(passportURL, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.PASSPORT_API_KEY}`,
+    }
+  });
+
+  const jsonResponse = await response.json();
+
+  const count: number = jsonResponse.count;
+  let passports: PassportResponse[] = jsonResponse.items;
+
+  return {
+    passports,
+    count
+  }
+}

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -9,6 +9,7 @@ import {
   QFContribution,
   RoundMetadata,
   QFDistribution,
+  PassportResponse,
 } from "./types";
 import prisma from "./handlers/client";
 
@@ -64,3 +65,35 @@ export const mockQFDistribution: QFDistribution = {
   uniqueContributorsCount: faker.datatype.number(),
   totalContributionsInUSD: faker.datatype.number(),
 };
+
+export const mockPassportAboveThreshold = () : PassportResponse => {
+  return {
+    "address": faker.finance.ethereumAddress(),
+    "score": "25",
+    "status": "DONE",
+    "last_score_timestamp": "2023-01-17T12:27:09.041074+00:00",
+    "evidence": {
+        "type": "ThresholdScoreCheck",
+        "success": true,
+        "rawScore": "25",
+        "threshold": "21.75812"
+    },
+    "error": null
+  };
+}
+
+export const mockPassportBelowThreshold = (): PassportResponse => {
+  return {
+    "address": faker.finance.ethereumAddress(),
+    "score": "5",
+    "status": "DONE",
+    "last_score_timestamp": "2023-01-17T12:27:09.041074+00:00",
+    "evidence": {
+        "type": "ThresholdScoreCheck",
+        "success": false,
+        "rawScore": "5",
+        "threshold": "21.75812"
+    },
+    "error": null
+  };
+}

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -51,6 +51,27 @@ export type HandleResponseObject = {
   data: object;
 };
 
+
+/****************/
+/* = Passport = */
+/****************/
+type PassportEvidence = {
+  type: string;
+  rawScore: string;
+  threshold: string;
+  success: boolean;
+};
+
+export type PassportResponse = {
+  address?: string;
+  score?: string;
+  status?: string;
+  last_score_timestamp?: string;
+  evidence?: PassportEvidence;
+  error?: string|null;
+  detail?: string;
+};
+
 /****************/
 /* = LinearQF = */
 /****************/

--- a/packages/api/src/votingStrategies/linearQuadraticFunding.ts
+++ b/packages/api/src/votingStrategies/linearQuadraticFunding.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "ethers";
+import { BigNumber, ethers } from "ethers";
 import { formatUnits, getAddress } from "ethers/lib/utils";
 import {
   ChainId,
@@ -17,6 +17,9 @@ import {
   fetchAverageTokenPrices,
   fetchProjectIdToPayoutAddressMapping,
 } from "../utils";
+import {
+  fetchContributorsAboveThreshold
+} from "../sybilProtection/passport";
 
 /**
  * summarizeRound is an async function that summarizes a round of voting by counting the number of contributions, the number of unique contributors, the total amount of contributions in USD, and the average contribution in USD.
@@ -451,6 +454,9 @@ export const matchQFContributions = async (
 
   let matchResults: QFDistribution[] = [];
   let totalMatchInUSD = 0;
+
+  const contributorsWhoShouldBeMatched = await fetchContributorsAboveThreshold();
+
   for (const projectId in contributionsByProject) {
     let sumOfSquares = 0;
     let sumOfContributions = 0;
@@ -465,7 +471,12 @@ export const matchQFContributions = async (
 
       uniqueContributors.add(contributor);
 
-      if (usdValue) {
+      const checksumAddress = ethers.utils.getAddress(contributor)
+
+      if (
+        usdValue &&
+        contributorsWhoShouldBeMatched.includes(checksumAddress)
+      ) {
         sumOfSquares += Math.sqrt(usdValue);
         sumOfContributions += usdValue;
       }


### PR DESCRIPTION
##### Description

Looks like passport bulk API is quite slow. 
Fetching all passport score for a given community requires a GET call which limits results to 1000.
and each call takes about 3 seconds and currently there are 8000 stamps (and this will increase over time)

We will need to figure out a more scalable solution

fixes #990