### PR TITLE
fix(navbar, 404): broken links to homepage

### DIFF
--- a/packages/grant-explorer/src/features/common/Navbar.tsx
+++ b/packages/grant-explorer/src/features/common/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { ReactComponent as GitcoinLogo } from "../../assets/gitcoinlogo-black.svg";
 import { ReactComponent as GrantsExplorerLogo } from "../../assets/topbar-logos-black.svg";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
@@ -10,6 +10,7 @@ export interface NavbarProps {
 }
 
 export default function Navbar(props: NavbarProps) {
+  const { chainId, roundId } = useParams();
   const [shortlist] = useBallot();
 
   return (
@@ -18,7 +19,7 @@ export default function Navbar(props: NavbarProps) {
         <div className="flex justify-between h-16">
           <div className="flex">
             <Link
-              to="#"
+              to={`/round/${chainId}/${roundId}`}
               className="flex-shrink-0 flex items-center"
               data-testid={"home-link"}
             >

--- a/packages/grant-explorer/src/features/common/NotFoundPage.tsx
+++ b/packages/grant-explorer/src/features/common/NotFoundPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import Navbar from "./Navbar";
 import { Button } from "./styles";
 import { ReactComponent as NotFoundBanner } from "../../assets/404.svg";
@@ -8,6 +8,8 @@ import Footer from "./Footer";
 export default function NotFoundPage() {
   datadogLogs.logger.info(`====> Route: NotFound`);
   datadogLogs.logger.info(`====> URL: ${window.location.href}`);
+
+  const { chainId, roundId } = useParams();
 
   return (
       <>
@@ -27,8 +29,10 @@ export default function NotFoundPage() {
                   <a href="https://discord.com/invite/gitcoin">Discord.</a>
                 </p>
 
-                <Link to="/" data-testid={"not-found-go-back-home"}
->
+                <Link
+                  to={`/round/${chainId}/${roundId}`}
+                  data-testid={"not-found-go-back-home"}
+                >
                   <Button
                     $variant="outline"
                     type="button"


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

Neither `"#"` nor `"/"` point to the grants round homepage. You can see this bug by going to https://grant-explorer.gitcoin.co/#/round/1/404 and observing the infinite loop, or trying to click on the nav bar to go home. It has been changed to ``/round/${chainId}/${roundId}`` which is used elsewhere in the app and is correct.

##### Refers/Fixes

N/A

##### Testing

N/A - change too minor
