### PR TITLE
1043 coingecko price

### DIFF
--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -308,8 +308,7 @@ export async function getStartAndEndTokenPrices(
         `ChainId ${chainId} is not supported by CoinGecko's API.`
       );
     }
-    let validAddress = getValidTokenAddress(chainId, contract);
-    const url = `https://api.coingecko.com/api/v3/coins/${chainName}/contract/${validAddress}/market_chart/range?vs_currency=usd&from=${startTime}&to=${endTime}`;
+    const url = `https://api.coingecko.com/api/v3/coins/${chainName}/contract/${contract}/market_chart/range?vs_currency=usd&from=${startTime}&to=${endTime}`;
     const res = await fetch(url, {
       headers: {
         Accept: "application/json",
@@ -433,13 +432,9 @@ export const fetchCurrentTokenPrices = async (
       return testnetTokenPrices;
     };
 
-    let validAddresses = tokenAddresses.map( (tokenAddress) => {
-      getValidTokenAddress(chainId, tokenAddress);
-    });
-
     const { chainName } = getChainName(chainId);
 
-    const tokenPriceEndpoint = `https://api.coingecko.com/api/v3/simple/token_price/${chainName}?contract_addresses=${validAddresses.join(
+    const tokenPriceEndpoint = `https://api.coingecko.com/api/v3/simple/token_price/${chainName}?contract_addresses=${tokenAddresses.join(
       ","
     )}&vs_currencies=usd`;
 
@@ -529,7 +524,7 @@ export const fetchAverageTokenPrices = async (
       if (address !== "0x0000000000000000000000000000000000000000") {
         try {
           // get valid address for tokens that are not on coingecko
-          let validAddress = getValidTokenAddress(chainId, address);
+          const validAddress = getValidCoinGeckoTokenAddress(chainId, address);
           const tokenPriceEndpoint = `https://api.coingecko.com/api/v3/coins/${chainName}/contract/${validAddress}/market_chart/range?vs_currency=usd&from=${startTime}&to=${endTime}`;
           const resTokenPriceEndpoint = await fetch(tokenPriceEndpoint, {
             method: "GET",
@@ -659,7 +654,7 @@ export const isTestnet = (chainId: ChainId) => {
 };
 
 /**
- * Util function to specify valid address in scenarios where
+ * Util function to specify valid coingecko address in scenarios where
  * coingecko doesn't return token price on given chain.
  * Ideally usefully for stable coins
  * 
@@ -668,7 +663,7 @@ export const isTestnet = (chainId: ChainId) => {
  * 
  * @returns validAddress
  */
-export const getValidTokenAddress = (chainId: ChainId, address: string) => {
+export const getValidCoinGeckoTokenAddress = (chainId: ChainId, address: string) => {
   let validAddress = address;
   if (chainId == ChainId.FANTOM_MAINNET) {
     if (address == "0xc931f61b1534eb21d8c11b24f3f5ab2471d4ab50") { // BUSD

--- a/packages/api/src/utils.ts
+++ b/packages/api/src/utils.ts
@@ -523,6 +523,8 @@ export const fetchAverageTokenPrices = async (
       averageTokenPrices[address] = 0;
       if (address !== "0x0000000000000000000000000000000000000000") {
         try {
+          // TODO:  update this to ensure BUSD price is set to DAI price in averageTokenPrices
+          address = getAlternateTokenAddress(chainId, address);
           const tokenPriceEndpoint = `https://api.coingecko.com/api/v3/coins/${chainName}/contract/${address}/market_chart/range?vs_currency=usd&from=${startTime}&to=${endTime}`;
           const resTokenPriceEndpoint = await fetch(tokenPriceEndpoint, {
             method: "GET",
@@ -638,7 +640,7 @@ export const fetchProjectIdToPayoutAddressMapping = async (
 
 /**
  * checks if current ChainId is testnet chain
- * @param chainId \
+ * @param chainId
  * @returns boolean
  */
 export const isTestnet = (chainId: ChainId) => {
@@ -650,3 +652,23 @@ export const isTestnet = (chainId: ChainId) => {
 
   return testnet.includes(chainId);
 };
+
+/**
+ * Util function to specify alternate address in scenarios where
+ * coingecko doesn't return token price on given chain.
+ * Ideally usefully for stable coins
+ * 
+ * @param chainId
+ * @param address 
+ * 
+ * @returns alternateAddress
+ */
+export const getAlternateTokenAddress = (chainId: ChainId, address: string) => {
+  let alternateAddress = address;
+  if (chainId == ChainId.FANTOM_MAINNET) {
+    if (address == "0xc931f61b1534eb21d8c11b24f3f5ab2471d4ab50") { // BUSD
+      alternateAddress = "0x8d11ec38a3eb5e956b052f67da8bdc9bef8abf3e" // DAI
+    }
+  }
+  return alternateAddress;
+}


### PR DESCRIPTION

##### Description

- Adds temporary util function which swaps BUSD price for DAI price on fantom as coingecko does not support this 
- This works only for matching endpoint (The summary endpoints still have this issue)
- A follow up issue is to be created to ensure we have a cleaner solution which can be used across all 3 endpoints to handle scenarios where coingecko doesn't have the rate of the token on a given chain ID

##### Refers/Fixes

fixes #1043

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
