### PR TITLE
feat: sticky nav bar

### DIFF
--- a/packages/grant-explorer/src/features/common/Navbar.tsx
+++ b/packages/grant-explorer/src/features/common/Navbar.tsx
@@ -13,7 +13,7 @@ export default function Navbar(props: NavbarProps) {
   const [shortlist] = useBallot();
 
   return (
-    <nav className="bg-white">
+    <nav className="bg-white fixed w-full z-10">
       <div className="mx-auto px-4 sm:px-6 lg:px-20">
         <div className="flex justify-between h-16">
           <div className="flex">

--- a/packages/grant-explorer/src/features/common/Navbar.tsx
+++ b/packages/grant-explorer/src/features/common/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { ReactComponent as GitcoinLogo } from "../../assets/gitcoinlogo-black.svg";
 import { ReactComponent as GrantsExplorerLogo } from "../../assets/topbar-logos-black.svg";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
@@ -11,6 +11,7 @@ export interface NavbarProps {
 
 export default function Navbar(props: NavbarProps) {
   const [shortlist] = useBallot();
+  const { chainId, roundId } = useParams();
 
   return (
     <nav className="bg-white fixed w-full z-10">
@@ -18,7 +19,7 @@ export default function Navbar(props: NavbarProps) {
         <div className="flex justify-between h-16">
           <div className="flex">
             <Link
-              to="#"
+              to={`/round/${chainId}/${roundId}`}
               className="flex-shrink-0 flex items-center"
               data-testid={"home-link"}
             >

--- a/packages/grant-explorer/src/features/common/NotFoundPage.tsx
+++ b/packages/grant-explorer/src/features/common/NotFoundPage.tsx
@@ -12,7 +12,7 @@ export default function NotFoundPage() {
   return (
       <>
         <Navbar roundUrlPath={""} />
-        <div className="lg:mx-20 h-screen px-4 py-7">
+        <div className="relative top-16 lg:mx-20 h-screen px-4 py-7">
           <main>
             <div className="flex pt-8">
               <div className="m-auto text-center mt-5">

--- a/packages/grant-explorer/src/features/common/PassportBanner.tsx
+++ b/packages/grant-explorer/src/features/common/PassportBanner.tsx
@@ -221,17 +221,19 @@ export default function PassportBanner(props: {
   };
 
   return (
-    <div className={bannerConfig[passportState].color}>
-      <div className="max-w-full py-3 px-3 sm:px-6 lg:px-8">
-        <div className="flex flex-row flex-wrap items-center justify-center">
-          <div className="relative">{bannerConfig[passportState].icon}</div>
-          <span
-            data-testid={bannerConfig[passportState].testId}
-            className="ml-3 font-medium text-sm"
-          >
-            {bannerConfig[passportState].body}
-          </span>
-          {bannerConfig[passportState].button}
+    <div className="relative top-16">
+      <div className={bannerConfig[passportState].color}>
+        <div className="max-w-full py-3 px-3 sm:px-6 lg:px-8 z-0">
+          <div className="flex flex-row flex-wrap items-center justify-center">
+            <div className="relative">{bannerConfig[passportState].icon}</div>
+            <span
+              data-testid={bannerConfig[passportState].testId}
+              className="ml-3 font-medium text-sm"
+            >
+              {bannerConfig[passportState].body}
+            </span>
+            {bannerConfig[passportState].button}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/grant-explorer/src/features/common/RoundEndedBanner.tsx
+++ b/packages/grant-explorer/src/features/common/RoundEndedBanner.tsx
@@ -2,11 +2,13 @@ import { ExclamationCircleIcon } from '@heroicons/react/24/solid'
 
 export default function RoundEndedBanner() {
   return (
-    <div className="bg-pink-100">
-      <div className="max-w-full py-3 px-3 sm:px-6 lg:px-8">
-        <div className="flex flex-row flex-wrap items-center justify-center">
-          <ExclamationCircleIcon className="fill-red-500 stroke-red-200 h-7 w-7 relative text-white items-center rounded-full"/>
-          <span className="ml-3 font-medium text-sm">This round has ended. Thank you for your support!</span>
+    <div className="relative top-16">
+      <div className="bg-pink-100">
+        <div className="max-w-full py-3 px-3 sm:px-6 lg:px-8 z-0">
+          <div className="flex flex-row flex-wrap items-center justify-center">
+            <ExclamationCircleIcon className="fill-red-500 stroke-red-200 h-7 w-7 relative text-white items-center rounded-full"/>
+            <span className="ml-3 font-medium text-sm">This round has ended. Thank you for your support!</span>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/grant-explorer/src/features/round/PassportConnect.tsx
+++ b/packages/grant-explorer/src/features/round/PassportConnect.tsx
@@ -293,7 +293,7 @@ export default function PassportConnect() {
   return (
     <>
       <Navbar roundUrlPath={`/round/${chainId}/${roundId}`} />
-      <div className="lg:mx-20 px-4 py-7 h-screen">
+      <div className="relative top-16 lg:mx-20 px-4 py-7 h-screen">
         <header>
           <div
             data-testid="breadcrumb"

--- a/packages/grant-explorer/src/features/round/ThankYou.tsx
+++ b/packages/grant-explorer/src/features/round/ThankYou.tsx
@@ -61,7 +61,7 @@ export default function ThankYou() {
   return (
     <>
       <Navbar roundUrlPath={`/round/${chainId}/${roundId}`} />
-      <div className="lg:mx-20 px-4 py-7 h-screen">
+      <div className="relative top-16 lg:mx-20 px-4 py-7 h-screen">
         <main>
           <div className="text-center">
             <h1 className="text-4xl my-8">Thank you for supporting our community.</h1>

--- a/packages/grant-explorer/src/features/round/ViewBallotPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewBallotPage.tsx
@@ -260,7 +260,7 @@ export default function ViewBallot() {
         </div>
       )}
       {}
-      <div className="lg:mx-20 h-screen px-4 py-7">
+      <div className="relative top-16 lg:mx-20 h-screen px-4 py-7">
         <main>
           {Header(chainId, roundId)}
           <div className="flex flex-col md:flex-row gap-4">

--- a/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
+++ b/packages/grant-explorer/src/features/round/ViewProjectDetails.tsx
@@ -80,7 +80,7 @@ export default function ViewProjectDetails() {
           <RoundEndedBanner />
         </div>
       )}
-      <div className="lg:mx-20 h-screen px-4 py-7">
+      <div className="relative top-16 lg:mx-20 h-screen px-4 py-7">
         <main>
           <div className="flex flex-row items-center gap-3 text-sm">
             <ChevronLeftIcon className="h-5 w-5 mt-6 mb-6" />

--- a/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
@@ -94,7 +94,7 @@ function BeforeRoundStart(props: {
   return (
     <>
       <Navbar roundUrlPath={`/round/${chainId}/${roundId}`} />
-      <div className="lg:mx-20 px-4 py-7 h-screen">
+      <div className="relative top-16 lg:mx-20 px-4 py-7 h-screen">
         <main>
           <PreRoundPage
             round={round}
@@ -177,7 +177,7 @@ function AfterRoundStart(props: {
           <RoundEndedBanner />
         </div>
       )}
-      <div className="lg:mx-20 px-4 py-7 h-screen">
+      <div className="relative top-16 lg:mx-20 px-4 py-7 h-screen">
         <main>
           <p className="text-3xl my-5">{round.roundMetadata?.name}</p>
 


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

As a user
I want to click on the Grants Explorer icon in the nav bar
So that I can go back to the main landing page

- [x]  Sticky nav bar
- [x]  Grants Explorer logo in the nav bar links to the main landing page

##### Refers/Fixes

fixes #1013 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
