### PR TITLE
feat: temporarily allow Passport banner post-round

### DIFF
--- a/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
+++ b/packages/grant-explorer/src/features/round/ViewRoundPage.tsx
@@ -169,7 +169,7 @@ function AfterRoundStart(props: {
   return (
     <>
       <Navbar roundUrlPath={`/round/${chainId}/${roundId}`} />
-      {props.isBeforeRoundEndDate && (
+      {props.isAfterRoundEndDate && (
         <PassportBanner chainId={chainId} roundId={roundId} />
       )}
       {props.isAfterRoundEndDate && (


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

As a donor
I want to be able to check my Passport score after the Alpha rounds end
So that I know if my score is eligible for matching

##### Refers/Fixes

fixes #1062 

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
