### PR TITLE
fix: app load fix

### DIFF
--- a/packages/builder/src/actions/projects.ts
+++ b/packages/builder/src/actions/projects.ts
@@ -419,20 +419,9 @@ export const fetchProjectApplications =
             addresses.projectRegistry
           );
 
-          // During the first alpha round, we created applications with the wrong chain id (using the
-          // round chain instead of the project chain). This is a fix to display the applications with
-          // the wrong application id. NOTE: there is a possibility of clash, because the contracts
-          // have the same address on multiple chains.
-          const projectApplicationIDWithChain =
-            generateUniqueRoundApplicationID(
-              chain.id,
-              projectID,
-              addresses.projectRegistry
-            );
-
           const response: any = await graphqlFetch(
-            `query roundProjects($projectID: String, $projectApplicationIDWithChain: String) {
-            roundProjects(where: { project_in: [$projectID, $projectApplicationIDWithChain] }) {
+            `query roundProjects($projectID: String) {
+            roundProjects(where: { project: $projectID }) {
               status
               round {
                 id
@@ -447,7 +436,6 @@ export const fetchProjectApplications =
             chain.id,
             {
               projectID: projectApplicationID,
-              projectApplicationIDWithChain,
             },
             reactEnv
           );


### PR DESCRIPTION
 During the first alpha round, we created applications with the wrong chain id (using the round chain instead of the project chain). This was a fix to display the applications with
the wrong application id. 

Removing this fix now that the app id's are correct.