### PR TITLE
fix: tweaked error message for passport failures, added Datadog logging

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -7,6 +7,7 @@ export enum PassportState {
   MATCH_INELIGIBLE,
   LOADING,
   ERROR,
+  INVALID_RESPONSE,
 }
 
 type PassportEvidence = {
@@ -40,7 +41,10 @@ type UsePassportHook = {
   refreshScore: () => Promise<void>;
 };
 
-export function usePassport(address: string, communityId: string): UsePassportHook {
+export function usePassport(
+  address: string,
+  communityId: string
+): UsePassportHook {
   const { data, error, mutate } = useSWR<PassportResponse>(
     [address, communityId],
     ([address, communityId]: [address: string, communityId: string]) =>
@@ -54,10 +58,9 @@ export function usePassport(address: string, communityId: string): UsePassportHo
       await mutate();
     },
     recalculateScore: () => submitPassport(address, communityId),
-    passport: data
+    passport: data,
   };
 }
-
 
 /**
  * Endpoint used to fetch the passport score for a given address
@@ -75,8 +78,8 @@ export const fetchPassport = (
     method: "GET",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${process.env.REACT_APP_PASSPORT_API_KEY}`
-    }
+      Authorization: `Bearer ${process.env.REACT_APP_PASSPORT_API_KEY}`,
+    },
   });
 };
 
@@ -97,13 +100,13 @@ export const submitPassport = (
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${process.env.REACT_APP_PASSPORT_API_KEY}`
+      Authorization: `Bearer ${process.env.REACT_APP_PASSPORT_API_KEY}`,
     },
     body: JSON.stringify({
       address,
       community: communityId,
       signature: "",
-      nonce: ""
-    })
+      nonce: "",
+    }),
   });
 };

--- a/packages/grant-explorer/src/features/common/PassportBanner.tsx
+++ b/packages/grant-explorer/src/features/common/PassportBanner.tsx
@@ -1,18 +1,18 @@
 import {
-  ExclamationCircleIcon,
-  CheckBadgeIcon,
-  XCircleIcon,
   ArrowTopRightOnSquareIcon,
+  CheckBadgeIcon,
+  ExclamationCircleIcon,
+  XCircleIcon,
 } from "@heroicons/react/24/solid";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAccount } from "wagmi";
+import { ReactComponent as PassportLogo } from "../../assets/passport-logo.svg";
 import {
   fetchPassport,
   PassportResponse,
   PassportState,
 } from "../api/passport";
-import { ReactComponent as PassportLogo } from "../../assets/passport-logo.svg";
-import { useEffect, useState } from "react";
-import { useAccount } from "wagmi";
-import { useNavigate } from "react-router-dom";
 
 export default function PassportBanner(props: {
   chainId?: string;
@@ -218,6 +218,15 @@ export default function PassportBanner(props: {
       color: "bg-red-200",
       testId: "error-loading-passport",
       body: "An error occurred while loading your Gitcoin Passport. Please try again later.",
+      button: null,
+    },
+    [PassportState.INVALID_RESPONSE]: {
+      icon: (
+        <ExclamationCircleIcon className="fill-red-500 stroke-red-200 h-7 w-7 relative text-white items-center rounded-full" />
+      ),
+      color: "bg-red-200",
+      testId: "error-loading-passport",
+      body: "Passport Profile not detected. Please open Passport to troubleshoot.",
       button: null,
     },
   };

--- a/packages/grant-explorer/src/features/round/PassportConnect.tsx
+++ b/packages/grant-explorer/src/features/round/PassportConnect.tsx
@@ -68,7 +68,7 @@ export default function PassportConnect() {
           `error: callFetchPassport - invalid score response`,
           scoreResponse
         );
-        setPassportState(PassportState.INVALID_PASSPORT);
+        setPassportState(PassportState.INVALID_RESPONSE);
         return;
       }
 
@@ -257,6 +257,16 @@ export default function PassportConnect() {
           {passportState === PassportState.ERROR && (
             <div>
               <p className="text-pink-400 mb-2">Error In fetching passport</p>
+              <p>Please try again later.</p>
+            </div>
+          )}
+
+          {passportState === PassportState.INVALID_RESPONSE && (
+            <div>
+              <p className="text-pink-400 mb-2">
+                Passport Profile not detected. Please open Passport to
+                troubleshoot.
+              </p>
               <p>Please try again later.</p>
             </div>
           )}

--- a/packages/grant-explorer/src/features/round/PassportConnect.tsx
+++ b/packages/grant-explorer/src/features/round/PassportConnect.tsx
@@ -264,10 +264,9 @@ export default function PassportConnect() {
           {passportState === PassportState.INVALID_RESPONSE && (
             <div>
               <p className="text-pink-400 mb-2">
-                Passport Profile not detected. Please open Passport to
-                troubleshoot.
+                Passport Profile not detected.
               </p>
-              <p>Please try again later.</p>
+              <p>Please open Passport to troubleshoot.</p>
             </div>
           )}
         </div>

--- a/packages/grant-explorer/src/features/round/__tests__/PassportConnect.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/PassportConnect.test.tsx
@@ -176,11 +176,11 @@ describe("<PassportConnect/>", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(
-            "Passport Profile not detected. Please open Passport to troubleshoot."
-          )
+          screen.getByText("Passport Profile not detected.")
         ).toBeInTheDocument();
-        expect(screen.getByText("Please try again later.")).toBeInTheDocument();
+        expect(
+          screen.getByText("Please open Passport to troubleshoot.")
+        ).toBeInTheDocument();
       });
     });
 

--- a/packages/grant-explorer/src/features/round/__tests__/PassportConnect.test.tsx
+++ b/packages/grant-explorer/src/features/round/__tests__/PassportConnect.test.tsx
@@ -1,9 +1,9 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { faker } from "@faker-js/faker";
-import PassportConnect from "../PassportConnect";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
-import { fetchPassport, submitPassport } from "../../api/passport";
 import { mockBalance, mockNetwork, mockSigner } from "../../../test-utils";
+import { fetchPassport, submitPassport } from "../../api/passport";
+import PassportConnect from "../PassportConnect";
 
 const chainId = 5;
 const roundId = faker.finance.ethereumAddress();
@@ -154,7 +154,7 @@ describe("<PassportConnect/>", () => {
       jest.clearAllMocks();
     });
 
-    it("IF passport state return error status THEN it shows error in fetching passport", async () => {
+    it("IF passport state return error status THEN it shows issue in fetching passport", async () => {
       const mockJsonPromise = Promise.resolve({
         score: "-1",
         address: userAddress,
@@ -176,7 +176,9 @@ describe("<PassportConnect/>", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("Error In fetching passport")
+          screen.getByText(
+            "Passport Profile not detected. Please open Passport to troubleshoot."
+          )
         ).toBeInTheDocument();
         expect(screen.getByText("Please try again later.")).toBeInTheDocument();
       });


### PR DESCRIPTION
Fixes #1113 

This makes the error message a bit more clear to the user (and us) when the passport API returns an error.

I also added Datadog logging to our passport connection logic to make it easier to troubleshoot in case we don't have a way to repro (like in this case).