### PR TITLE
fix: production build fail

### DIFF
--- a/packages/grant-explorer/src/features/common/CustomerSupport.tsx
+++ b/packages/grant-explorer/src/features/common/CustomerSupport.tsx
@@ -1,14 +1,14 @@
-import { useEffect, useRef, useState } from "react";
 import {
-  QuestionMarkCircleIcon,
   BookOpenIcon,
   ChatBubbleLeftRightIcon,
   ClipboardDocumentListIcon,
+  QuestionMarkCircleIcon,
 } from "@heroicons/react/24/outline";
 import { Button } from "common/src/styles";
+import { useEffect, useRef, useState } from "react";
 
 type Menu = {
-  Icon: (props: React.ComponentProps<"svg">) => JSX.Element;
+  Icon: React.FC<React.SVGProps<SVGSVGElement>>;
   title: string;
   subTitle: string;
   link: string;


### PR DESCRIPTION
This should fix the error we are seeing in the prod deployment:

```
2:58:13 PM 02/10/2023: Failed to compile.
2:58:13 PM 02/10/2023: TS2322: Type 'ForwardRefExoticComponent<SVGProps<SVGSVGElement> & { title?: string | undefined; titleId?: string | undefined; }>' is not assignable to type '(props: SVGProps<SVGSVGElement>) => Element'.
2:58:13 PM 02/10/2023: Type 'ReactElement<any, string | JSXElementConstructor<any>> | null' is not assignable to type 'Element'.
2:58:13 PM 02/10/2023: Type 'null' is not assignable to type 'ReactElement<any, any>'.
2:58:13 PM 02/10/2023: 17 | export const menuItems: Menu[] = [
2:58:13 PM 02/10/2023: 18 | {
2:58:13 PM 02/10/2023: > 19 | Icon: BookOpenIcon,
2:58:13 PM 02/10/2023: | ^^^^
2:58:13 PM 02/10/2023: 20 | title: "Grants Explorer Guide",
2:58:13 PM 02/10/2023: 21 | subTitle: "Best practices for project owners",
2:58:13 PM 02/10/2023: 22 | link: "https://support.gitcoin.co/gitcoin-knowledge-base/gitcoin-grants-protocol/funder-faq/grants-explorer-guide",
2:58:13 PM 02/10/2023: ELIFECYCLE  Command failed with exit code 1.
2:58:36 PM 02/10/2023: Error occured during the build.
```