### PR TITLE
Fix duplicate Github Action runs

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,9 +1,12 @@
 name: package/api - Build -> Test
 on:
   push:
-  pull_request:
     branches:
       - main
+      - release
+  pull_request:
+    branches:
+      - "**"
 jobs:
   build-and-deploy:
     concurrency: ci-api-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -6,6 +6,8 @@ on:
       - main
       - release
   pull_request:
+    branches:
+      - "**"
 
 jobs:
   build:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,9 +2,10 @@ name: package/builder - Build -> Test
 
 on:
   push:
-  pull_request:
     branches:
-      - "**"
+      - main
+      - release
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -1,9 +1,10 @@
 name: package/contracts - Build -> Test
 on:
   push:
-  pull_request:
     branches:
       - main
+      - release
+  pull_request:
 jobs:
   tests:
     concurrency: ci-contract-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/contract.yml
+++ b/.github/workflows/contract.yml
@@ -5,6 +5,8 @@ on:
       - main
       - release
   pull_request:
+    branches:
+      - "**"
 jobs:
   tests:
     concurrency: ci-contract-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/grant-explorer.yml
+++ b/.github/workflows/grant-explorer.yml
@@ -1,9 +1,10 @@
 name: package/grant-explorer - Build -> Test
 on:
   push:
-  pull_request:
     branches:
       - main
+      - release
+  pull_request:
 jobs:
   build-and-deploy:
     concurrency: ci-grant-explorer-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/grant-explorer.yml
+++ b/.github/workflows/grant-explorer.yml
@@ -5,6 +5,8 @@ on:
       - main
       - release
   pull_request:
+    branches:
+      - "**"
 jobs:
   build-and-deploy:
     concurrency: ci-grant-explorer-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/graph-project-registry.yml
+++ b/.github/workflows/graph-project-registry.yml
@@ -5,6 +5,8 @@ on:
       - main
       - release
   pull_request:
+    branches:
+      - "**"
 jobs:
   build-and-deploy:
     concurrency: ci-graph-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/graph-project-registry.yml
+++ b/.github/workflows/graph-project-registry.yml
@@ -1,9 +1,10 @@
 name: package/graph/project-registry - Build -> Test
 on:
   push:
-  pull_request:
     branches:
       - main
+      - release
+  pull_request:
 jobs:
   build-and-deploy:
     concurrency: ci-graph-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/graph-round.yml
+++ b/.github/workflows/graph-round.yml
@@ -5,6 +5,8 @@ on:
       - main
       - release
   pull_request:
+    branches:
+      - "**"
 jobs:
   build-and-deploy:
     concurrency: ci-graph-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/graph-round.yml
+++ b/.github/workflows/graph-round.yml
@@ -1,9 +1,10 @@
 name: package/graph/round - Build -> Test
 on:
   push:
-  pull_request:
     branches:
       - main
+      - release
+  pull_request:
 jobs:
   build-and-deploy:
     concurrency: ci-graph-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/round-manager.yml
+++ b/.github/workflows/round-manager.yml
@@ -5,6 +5,8 @@ on:
       - main
       - release
   pull_request:
+    branches:
+      - "**"
 jobs:
   build-and-deploy:
     concurrency: ci-round-manager-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/round-manager.yml
+++ b/.github/workflows/round-manager.yml
@@ -1,9 +1,10 @@
 name: package/round-manager - Build -> Test
 on:
   push:
-  pull_request:
     branches:
       - main
+      - release
+  pull_request:
 jobs:
   build-and-deploy:
     concurrency: ci-round-manager-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
<!-- 
Thank you for your pull request! Please review the requirements below 
and ensure your pull request has fulfilled all requirements outlined in the target package.
-->

##### Description

We're currently executing duplicate actions on each push for a PR, with 7 workflows inside the repository it gets really noisy.

This PR reduces the checks from 18 to 11.

It implements the following behavior for all our workflows:

- All pushes to `main` and `release` will run checks, regardless if they're part of a PR or not, this includes merges
- Commits pushed to branches that have a PR will run checks once
- Commits pushed to branches that don't have a PR will not run checks

<!-- Describe your changes here. -->

##### Refers/Fixes

<!-- If this PR is related to a GitHub issue, please add a link here. -->

##### Testing

<!-- All PRs should be accompanied by tests! If you haven't added tests, please explain here. -->
