### PR TITLE
fix: add alchemy/infura key usage and priority to wagmi

### DIFF
--- a/packages/round-manager/.env.sample
+++ b/packages/round-manager/.env.sample
@@ -11,6 +11,7 @@ REACT_APP_SUBGRAPH_FANTOM_MAINNET_API=################
 
 # Ethereum Providers
 REACT_APP_INFURA_ID=######################
+REACT_APP_ALCHEMY_ID=######################
 
 # Datadog Monitoring
 REACT_APP_DATADOG_APPLICATION_ID=######################

--- a/packages/round-manager/src/app/wagmi.ts
+++ b/packages/round-manager/src/app/wagmi.ts
@@ -11,6 +11,7 @@ import { createClient, configureChains, chain } from "wagmi";
 
 import { publicProvider } from "wagmi/providers/public";
 import { infuraProvider } from "wagmi/providers/infura";
+import { alchemyProvider } from "wagmi/providers/alchemy";
 
 const testnetChains = () => {
   /***********************/
@@ -78,8 +79,9 @@ const allChains: Chain[] =
 export const { chains, provider, webSocketProvider } = configureChains(
   allChains,
   [
-    infuraProvider({ apiKey: process.env.REACT_APP_INFURA_ID }),
-    publicProvider(),
+    infuraProvider({ apiKey: process.env.REACT_APP_INFURA_ID, priority: 0 }),
+    alchemyProvider({ apiKey: process.env.REACT_APP_ALCHEMY_ID, priority: 1 }),
+    publicProvider({ priority: 2 }),
   ]
 );
 


### PR DESCRIPTION
note: I added the Infura env var and left the Alechmy one as a dummy var, until we sort it out, to our fleek round manager deployments. 
Be sure to check the new .env.example. 

It will still fallback to the public key if not on mainnet because we have not setup infura/alchemy for each project and chain (which incurs additional costs). 

But at least on mainnet - it should use our production infura key. 

fixes #1173 