### PR TITLE
chore: remove reclaimLockEndTime

### DIFF
--- a/packages/contracts/.openzeppelin/unknown-31337.json
+++ b/packages/contracts/.openzeppelin/unknown-31337.json
@@ -428,7 +428,7 @@
     },
     "a305a117446dca6870e3c60050d4f1ac35dc6251d76823b4d8e80c2f7e999811": {
       "address": "0xf4B146FbA71F41E0592668ffbF264F1D186b2Ca8",
-      "txHash": "0x1858955628f6b3b75a5c12f83400a81c2d872677dd7e005dd39f6451b7883701",
+      "txHash": "0x809fc733d00bc5ba02f18ec3b42c526dd1035ed2d3b2c879b4be08f9df399bb2",
       "layout": {
         "solcVersion": "0.8.17",
         "storage": [
@@ -532,7 +532,7 @@
     },
     "3284793f26e0643afe284876170d3a22a4886a77aa3df44f11776ba9fce29c8e": {
       "address": "0xB2b580ce436E6F77A5713D80887e14788Ef49c9A",
-      "txHash": "0x630813b8717c6364710e594d784c5888302a7d82748661a74b88fbdb9af1c8a2",
+      "txHash": "0xd0ee2f3a7e1052c35a91ca64d8fb4a53f3444c8b71bc8aeaa6cc288f9120d4b5",
       "layout": {
         "solcVersion": "0.8.17",
         "storage": [

--- a/packages/contracts/docs/contracts/payoutStrategy/IPayoutStrategy.md
+++ b/packages/contracts/docs/contracts/payoutStrategy/IPayoutStrategy.md
@@ -106,23 +106,6 @@ Invoked by RoundImplementation to trigger payout
 |---|---|---|
 | _encodedPayoutData | bytes[] | encoded payout data |
 
-### reclaimLockEndTime
-
-```solidity
-function reclaimLockEndTime() external view returns (uint256)
-```
-
-Reclaim lock end time
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### roundAddress
 
 ```solidity

--- a/packages/contracts/docs/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyImplementation.md
+++ b/packages/contracts/docs/contracts/payoutStrategy/MerklePayoutStrategy/MerklePayoutStrategyImplementation.md
@@ -189,23 +189,6 @@ payout function defined in IPayoutStrategy
 |---|---|---|
 | _distributions | bytes[] | encoded distribution |
 
-### reclaimLockEndTime
-
-```solidity
-function reclaimLockEndTime() external view returns (uint256)
-```
-
-Reclaim lock end time
-
-
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined |
-
 ### roundAddress
 
 ```solidity

--- a/packages/contracts/docs/upgrades/IPayoutStrategy/v0.2.0.md
+++ b/packages/contracts/docs/upgrades/IPayoutStrategy/v0.2.0.md
@@ -9,13 +9,11 @@
 **New Modifiers**
   - `isRoundOperator` - calls `RoundImplementation.hasRole()` to check if caller is Round Operator
   - `roundHasEnded` - calls `RoundImplementation.roundEndTime()` to check if round has ended
-  - `reclaimTimelockHasEnded` - checks to see if operator is allowed to withdraw funds (currently set to round end time) 
 
 **New Variables**
   - `roundAddress` - linked round address
   - `tokenAddress` -  round payout token
   - `distributionMetaPtr` - meta ptr storing raw results
-  - `reclaimLockEndTime` - timestamp after which opearator can withdraw funds
   - `isReadyForPayout` - boolean to capture if changes in contract are final and payout can be initiated  
 
 **New Events**

--- a/packages/contracts/test/payoutStrategy/IPayoutInterface.test.ts
+++ b/packages/contracts/test/payoutStrategy/IPayoutInterface.test.ts
@@ -166,15 +166,6 @@ describe("IPayoutInterface", function () {
         const tx = merklePayoutStrategy.init();
         await expect(tx).to.revertedWith('roundAddress already set');
       });
-
-      it("SHOULD set default value", async() => {
-        expect(await merklePayoutStrategy.isReadyForPayout()).to.equal(false);
-
-        const roundEndTime = await roundImplementation.roundEndTime();
-        const endLockingTime = await merklePayoutStrategy.reclaimLockEndTime();
-        expect(endLockingTime).to.equal(roundEndTime);
-      });
-
     });
 
     describe('test: setReadyForPayout', () => {
@@ -294,7 +285,7 @@ describe("IPayoutInterface", function () {
         params = await initPayoutStrategy(_currentBlockTimestamp, merklePayoutStrategy);
 
         const tx = merklePayoutStrategy.withdrawFunds(Wallet.createRandom().address);        
-        await expect(tx).to.revertedWith('reclaim lockDuration not ended');
+        await expect(tx).to.revertedWith('Lock duration has not ended');
       });
 
       it("SHOULD not revert WHEN invoked when the contract has no funds", async() => {


### PR DESCRIPTION
##### Description

Removing [remove reclaimLockEndTime](https://github.com/gitcoinco/grants-round/commit/7b545db4bf1dbd4d5c05a94cb0edc03ae6fec05f) as it adds no value in this point
Currently this value is set on init based on the round end time BUT the round end time can change over the course of the round and that makes data inconsistent. It’s smarter to always fetch the latest round and then add the time lock
Also since this check is used only in withdraw. Moving this into the function is cheaper than having a modifier which won’t be used by anyone else